### PR TITLE
Update Mono_to_Hydrazine.cfg

### DIFF
--- a/GameData/RealFuels/Mono_to_Hydrazine.cfg
+++ b/GameData/RealFuels/Mono_to_Hydrazine.cfg
@@ -1,26 +1,26 @@
 // Made by Sippyfrog aka Jake From State Farm Johnson
 // Free to use by anyone, I just ask that this ^^^^^^ stays
 // Ideas and support pulled from work/sources of NathanKell and Sarbian
-// Made to look nicer and more user-friendly for any looking to pull from or alter while also removing outdated errors from previous versions of RealFuels or Module Manager
+// Made to look user-friendly for any looking to pull from or alter while also removing outdated errors from previous versions of RealFuels and Module Manager
 // Abstract: changes basic fuel tanks to use RealFuels resources, also makes RCS Thrusters use Hydrazine
 
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final 		// Turns tanks with LiquidFuel and Oxidizer as resources into ModuleFuelTanks
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final		// Turns tanks with LiquidFuel and Oxidizer as resources into ModuleFuelTanks
 {
 	MODULE
 	{
-		name = ModuleFuelTanks													// sets module
-		volume = 0																		// creates a blank volume for utilization
-		@volume = #$/RESOURCE[LiquidFuel]/amount$				// searches for amount of LiquidFuel to use as volume
-		@volume += #$/RESOURCE[Oxidizer]/amount$				// adds amount of Oxidizer to that number above
-		@volume *= 5 																	// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
-		type = Default 																	// makes default tank because it's easiest to use for rockets
+		name = ModuleFuelTanks		// sets module
+		volume = 0		// creates a blank volume for utilization
+		@volume = #$/RESOURCE[LiquidFuel]/amount$		// searches for amount of LiquidFuel to use as volume
+		@volume += #$/RESOURCE[Oxidizer]/amount$		// adds amount of Oxidizer to that number above
+		@volume *= 		// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
+		type = Default		// makes default tank because it's easiest to use for rockets
 	}
 
-	!RESOURCE[LiquidFuel]															// removes old LiquidFuel resources
+	!RESOURCE[LiquidFuel]		// removes old LiquidFuel resources
 	{
 	}
 	
-	!RESOURCE[Oxidizer]															// removes old Oxidizer resources
+	!RESOURCE[Oxidizer]		// removes old Oxidizer resources
 	{
 	}
 }
@@ -29,72 +29,72 @@
 {
 	MODULE
 	{
-		name = ModuleFuelTanks													// sets module
-		volume = 0																		// creates a blank volume for utilization
-		@volume = #$/RESOURCE[LiquidFuel]/amount$				// searches for amount of LiquidFuel to use as volume
-		@volume *= 5																	// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
-		type = Fuselage																// makes into aircraft fuselage tank
+		name = ModuleFuelTanks		// sets module
+		volume = 0		// creates a blank volume for utilization
+		@volume = #$/RESOURCE[LiquidFuel]/amount$		// searches for amount of LiquidFuel to use as volume
+		@volume *= 5		// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
+		type = Fuselage		// makes into aircraft fuselage tank
 	}
 	
-	!RESOURCE[LiquidFuel]															// removes old LiquidFuel resources
+	!RESOURCE[LiquidFuel]		// removes old LiquidFuel resources
 	{
 	}
 }
 
-@PART[*]:HAS[@RESOURCE[MonoPropellant],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final			// Does exact same process above except for RCS tanks
+@PART[*]:HAS[@RESOURCE[MonoPropellant],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final		// Does exact same process above except for RCS tanks
 {
 	MODULE
 	{
-		name = ModuleFuelTanks													// sets module
-		volume = 0																		// creates a blank volume for utilization
+		name = ModuleFuelTanks		// sets module
+		volume = 0		// creates a blank volume for utilization
 		@volume = #$/RESOURCE[MonoPropellant]/amount$		// searches for previous amount of MonoPropellant to use as volume
-		@volume *= 5																	// multiplies by 5
-		type = ServiceModule														// this is best type to use for RCS tanks, holds more specialized stuff like Hydrazine
+		@volume *= 5		// multiplies by 5
+		type = ServiceModule		// this is best type to use for RCS tanks, holds more specialized stuff like Hydrazine
 	}
 	
-	!RESOURCE[MonoPropellant]													// removes old MonoPropellant resources
+	!RESOURCE[MonoPropellant]		// removes old MonoPropellant resources
 	{
 	}
 }
 
-@PART[*]:HAS[@RESOURCE[MonoPropellant],@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final			// Any tanks with all 3 resources, i.e. Service Modules, replaces with 1 tank for RCS fuel and another for Fuel
+@PART[*]:HAS[@RESOURCE[MonoPropellant],@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final		// Any tanks with all 3 resources, i.e. Service Modules, replaces with 1 tank for RCS fuel and another for Fuel
 {
 	MODULE
 	{
-		name = ModuleFuelTanks													// sets module
-		volume = 0																		// creates a blank volume for utilization
+		name = ModuleFuelTanks		// sets module
+		volume = 0		// creates a blank volume for utilization
 		@volume = #$/RESOURCE[MonoPropellant]/amount$		// searches for previous amount of MonoPropellant to use as volume
-		@volume *= 5																	// multiplies by 5
-		type = ServiceModule														// this is best type to use for RCS tanks, holds more specialized stuff like Hydrazine
+		@volume *= 5		// multiplies by 5
+		type = ServiceModule		// this is best type to use for RCS tanks, holds more specialized stuff like Hydrazine
 	}
 
 	MODULE
 	{
-		name = ModuleFuelTanks													// sets module
-		volume = 0																		// creates a blank volume for utilization
-		@volume = #$/RESOURCE[LiquidFuel]/amount$				// searches for amount of LiquidFuel to use as volume
-		@volume += #$/RESOURCE[Oxidizer]/amount$				// adds amount of Oxidizer to that number above
-		@volume *= 5 																	// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
-		type = Default 																	// makes default tank because it's easiest to use for rockets
+		name = ModuleFuelTanks		// sets module
+		volume = 0		// creates a blank volume for utilization
+		@volume = #$/RESOURCE[LiquidFuel]/amount$		// searches for amount of LiquidFuel to use as volume
+		@volume += #$/RESOURCE[Oxidizer]/amount$		// adds amount of Oxidizer to that number above
+		@volume *= 		// multiplies entire volume by 5, this is standard conversion procedures for RealFuels
+		type = Defaul		// makes default tank because it's easiest to use for rockets
 	}
 	
-	!RESOURCE[MonoPropellant]													// removes old MonoPropellant resources
+	!RESOURCE[MonoPropellant]		// removes old MonoPropellant resources
 	{
 	}
 	
-	!RESOURCE[Oxidizer]															// removes old Oxidizer resources
+	!RESOURCE[Oxidizer]		// removes old Oxidizer resources
 	{
 	}
 	
-	![RESOURCE[LiquidFuel]														// removes old LiquidFuel resources
+	![RESOURCE[LiquidFuel]		// removes old LiquidFuel resources
 	{
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCS*]:HAS[@resourceName[MonoPropellant]]]:NEEDS[RealFuels]:Final			// turns all RCS thrusters not explicitly changed to use Hydrazine instead of MonoPropellant
+@PART[*]:HAS[@MODULE[ModuleRCS*]:HAS[@resourceName[MonoPropellant]]]:NEEDS[RealFuels]:Final		// turns all RCS thrusters not explicitly changed to use Hydrazine instead of MonoPropellant
 {
-	@MODULE[ModuleRCS*]														// searches for and prepares to alter modules beginning with ModuleRCS, beginning because it will also include modules of ModuleRCSFX if that mod is installed
+	@MODULE[ModuleRCS*]		// searches for and prepares to alter modules beginning with ModuleRCS, beginning because it will also include modules of ModuleRCSFX if that mod is installed
 	{
-		@resourceName = Hydrazine											// changes default propellant of RCS thruster to Hydrazine
+		@resourceName = Hydrazine		// changes default propellant of RCS thruster to Hydrazine
 	}
 }


### PR DESCRIPTION
Would it look better if the "// this does this..." parameters were simply put a couple tabs away from each of their parent? ATM I have them (when done in NotePad++, which I like to use for coding assistance and visualization) all aligned the same, HOWEVER, when viewed in really anything else it looks messy. So here in this edit I put them 2 tabs away each.

Should I keep it this way?
