### PR TITLE
Multimode support, KSPI "compatibility", more engines

### DIFF
--- a/GameData/RealFuels/Jet_modularEngines.cfg
+++ b/GameData/RealFuels/Jet_modularEngines.cfg
@@ -1,6 +1,8 @@
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:NEEDS[!WarpPlugin,RealFuels]:Final
+//engineAccelerationSpeed node allows it to target all jet engines while leaving everything else alone
+
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:Final
 {
-	@MODULE[ModuleEngines*],*
+	@MODULE[ModuleEngines*]:HAS[#engineAccelerationSpeed]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
@@ -9,9 +11,9 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:NEEDS[!WarpPlugin,RealFuels]:Final
+@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:Final
 {
-	@MODULE[ModuleEngines*],*
+	@MODULE[ModuleEngines*]:HAS[#engineAccelerationSpeed]
 	{
 		@PROPELLANT[Oxidizer]
 		{
@@ -20,7 +22,7 @@
 	}
 }
 
-@PART[RAPIER]:NEEDS[!WarpPlugin,RealFuels]:Final
+@PART[RAPIER]:NEEDS[RealFuels]:Final
 {
 	@MODULE[ModuleEnginesFX]:HAS[#engineID[ClosedCycle]]
 	{

--- a/GameData/RealFuels/StockAlike_RCS_RF.cfg
+++ b/GameData/RealFuels/StockAlike_RCS_RF.cfg
@@ -1,3 +1,5 @@
+//added B9 R6 RCS
+
 @PART[RCSBlock]:FOR[RealFuels_StockEngines] //
 {
  @mass = 0.029
@@ -3748,6 +3750,178 @@
   {
    name = MonoPropellant
    thrusterPower = 0.434
+
+   PROPELLANT
+   {
+    name = MonoPropellant
+    ratio = 1
+   }
+   IspSL = 0.243
+   IspV = 0.64
+
+
+   }
+  CONFIG
+  {
+   name = Aerozine50+NTO
+   thrusterPower = 0.75
+
+   PROPELLANT
+   {
+    name = Aerozine50
+    ratio = 0.48657718
+   }
+   PROPELLANT
+   {
+    name = NTO
+    ratio = 0.51342282
+   }
+   IspSL = 0.403
+   IspV = 0.955
+
+
+   }
+
+ }
+}
+@PART[B9_Control_RCS_Block_R6]:FOR[RealFuels_StockEngines] //R6 RCS Thruster Block
+{
+ @mass = 0.035
+
+ @MODULE[ModuleRCS*]
+ {
+  @name = ModuleRCSFX
+  @thrusterPower = 0.65
+  !resourceName = DELETE
+  @atmosphereCurve
+  {
+   @key,0 = 0 281
+   @key,1 = 1 101
+  }
+  !PROPELLANT[LiquidFuel] {}
+  !PROPELLANT[Oxidizer] {}
+  !PROPELLANT[MonoPropellant] {}
+  PROPELLANT
+  {
+   name = Hydrazine
+   ratio = 100
+  }
+ }
+
+ MODULE
+ {
+  name = ModuleEngineConfigs
+  type = ModuleRCSFX
+  techLevel = 1
+  origTechLevel = 1
+  engineType = L
+  origMass = 0.035
+  configuration = Hydrazine
+  modded = false
+  CONFIG
+  {
+   name = MMH+NTO
+   thrusterPower = 0.70
+
+   PROPELLANT
+   {
+    name = MMH
+    ratio = 0.51135562
+   }
+   PROPELLANT
+   {
+    name = NTO
+    ratio = 0.48864438
+   }
+   IspSL = 0.4
+   IspV = 0.952
+
+
+   }
+  CONFIG
+  {
+   name = Hydrazine
+   thrusterPower = 0.65
+
+   PROPELLANT
+   {
+    name = Hydrazine
+    ratio = 1
+   }
+   IspSL = 0.23
+   IspV = 0.72
+
+
+   }
+  CONFIG
+  {
+   name = HTP
+   thrusterPower = 0.55
+
+   PROPELLANT
+   {
+    name = HTP
+    ratio = 1
+   }
+   IspSL = 0.2
+   IspV = 0.465
+
+
+   }
+  CONFIG
+  {
+   name = Nitrogen
+   thrusterPower = 0.60
+
+   PROPELLANT
+   {
+    name = Nitrogen
+    ratio = 1
+   }
+   IspSL = 0.1
+   IspV = 0.195
+
+
+   }
+  CONFIG
+  {
+   name = NitrousOxide
+   thrusterPower = 0.55
+
+   PROPELLANT
+   {
+    name = NitrousOxide
+    ratio = 1
+   }
+   IspSL = 0.253
+   IspV = 0.5
+
+
+   }
+  CONFIG
+  {
+   name = UDMH+NTO
+   thrusterPower = 0.70
+
+   PROPELLANT
+   {
+    name = UDMH
+    ratio = 0.47823219
+   }
+   PROPELLANT
+   {
+    name = NTO
+    ratio = 0.52176781
+   }
+   IspSL = 0.396
+   IspV = 0.943
+
+
+   }
+  CONFIG
+  {
+   name = MonoPropellant
+   thrusterPower = 0.675
 
    PROPELLANT
    {

--- a/GameData/RealFuels/Stockalike_ATOMIC_AGE.cfg
+++ b/GameData/RealFuels/Stockalike_ATOMIC_AGE.cfg
@@ -1,9 +1,7 @@
-
+//added LANTR multimode
 
 @PART[nuclearEngineLANTR]:FOR[RealFuels_StockEngines] //LANTERN Engine
 {
-  !MODULE[MultiModeEngine]{}
-  !MODULE[ModuleEnginesFX],1 {} // index of 1 is the second MEFX node
   
   @EFFECTS,0 {
   -power_open,0 {}
@@ -19,7 +17,7 @@
   @maxTemp = 2400
   
   
-  @MODULE[ModuleEnginesFX]
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[Regular]]
   {
     @maxThrust = 62
     @heatProduction = 209
@@ -37,6 +35,36 @@
       ratio = 100.000000
       DrawGauge = True
     }
+    
+  }
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[Afterburner]]
+  {
+    @maxThrust = 155
+    @heatProduction = 418
+    @atmosphereCurve
+    {
+      @key,0 = 0 785
+      @key,1 = 1 345
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 84.29684902663367
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 15.703150973366334
+      }
+      PROPELLANT
+      {
+        name = U235Rods
+        ratio = 0.00000000001
+      }
     
   }
   

--- a/GameData/RealFuels/Stockalike_Constellation.cfg
+++ b/GameData/RealFuels/Stockalike_Constellation.cfg
@@ -1,3 +1,5 @@
+//added RS-68B
+
 @PART[constellationBNTR]:FOR[RealFuels_StockEngines] //Bimodal Nuclear Thermal Rocket
 {
 
@@ -213,4 +215,138 @@
     maxAmount = 9.333333333333334
   }
 
+}
+
+@PART[bahars68b]:FOR[RealFuels_StockEngines] //RS-68B
+{
+  @title = RS-68B
+  @mass = 6.412
+  @cost = 7039
+  %entryCost = 35195
+  @maxTemp = 2400
+  @description = The RS-68B is a Delta IV engine modified to meet the requirements of the Ares V.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 3552
+    @heatProduction = 189
+    @atmosphereCurve
+    {
+      @key,0 = 0 291
+      @key,1 = 1 323
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L+
+    origMass = 6.412
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 3552
+      heatProduction = 189
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.1500
+      IspV = 0.8500
+      throttle = 0.6
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 35.52
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 2664
+      heatProduction = 189
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4950
+      IspV = 1.0795
+      throttle = 0.6
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 35.52
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 35.52
+    }
+  }
+  
+  
 }

--- a/GameData/RealFuels/Stockalike_FASA.cfg
+++ b/GameData/RealFuels/Stockalike_FASA.cfg
@@ -604,7 +604,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -689,7 +689,7 @@
   MODULE
   {
     name = ModuleEngineIgnitor
-    ignitionsAvailable = 1
+    ignitionsAvailable = 4
     autoIgnitionTemperature = 800
     ignitorType = Electric
     useUllageSimulation = true
@@ -968,7 +968,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -1132,16 +1132,16 @@
 @PART[FASA_Mercury_Redstone_Eng]:FOR[RealFuels_StockEngines] //Mercury Redstone
 {
 
-  @mass = 0.32
-  @cost = 248
-  %entryCost = 1240
-  @maxTemp = 1834
+  @mass = 0.336
+  @cost = 260
+  %entryCost = 1300
+  @maxTemp = 1847
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 133
-    @heatProduction = 147
+    @maxThrust = 143
+    @heatProduction = 149
     @atmosphereCurve
     {
       @key,0 = 0 263
@@ -1170,15 +1170,15 @@
     techLevel = 1
     origTechLevel = 1
     engineType = L+
-    origMass = 0.32
+    origMass = 0.336
     configuration = Ethanol75+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Ethanol75+LqdOxygen
-      maxThrust = 133
-      heatProduction = 147
+      maxThrust = 143
+      heatProduction = 149
       PROPELLANT
       {
         name = Ethanol75
@@ -1203,7 +1203,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.4
+          amount = 1.5
         }
       }
 
@@ -1220,7 +1220,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 1.4
+      amount = 1.5
     }
   }
 
@@ -1229,16 +1229,16 @@
 @PART[FASAApolloLFEJ2]:FOR[RealFuels_StockEngines] //Saturn J2 Engine
 {
 
-  @mass = 0.75
-  @cost = 1312
-  %entryCost = 6560
-  @maxTemp = 1946
+  @mass = 0.821
+  @cost = 1456
+  %entryCost = 7280
+  @maxTemp = 1960
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 319
-    @heatProduction = 138
+    @maxThrust = 356
+    @heatProduction = 139
     @atmosphereCurve
     {
       @key,0 = 0 443
@@ -1267,15 +1267,15 @@
     techLevel = 5
     origTechLevel = 5
     engineType = U
-    origMass = 0.75
+    origMass = 0.821
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 319
-      heatProduction = 138
+      maxThrust = 356
+      heatProduction = 139
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1300,7 +1300,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 4.25
+          amount = 4.75
         }
       }
 
@@ -1308,8 +1308,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 425
-      heatProduction = 138
+      maxThrust = 475
+      heatProduction = 139
       PROPELLANT
       {
         name = Kerosene
@@ -1334,7 +1334,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 4.25
+          amount = 4.75
         }
       }
 
@@ -1351,7 +1351,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 4.25
+      amount = 4.75
     }
   }
 
@@ -1360,16 +1360,16 @@
 @PART[FASAApolloLFEH1]:FOR[RealFuels_StockEngines] //Saturn H-1 Engine
 {
 
-  @mass = 0.24
-  @cost = 560
-  %entryCost = 2800
-  @maxTemp = 2222
+  @mass = 0.258
+  @cost = 610
+  %entryCost = 3050
+  @maxTemp = 2245
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 190
-    @heatProduction = 172
+    @maxThrust = 210
+    @heatProduction = 175
     @atmosphereCurve
     {
       @key,0 = 0 320
@@ -1398,15 +1398,15 @@
     techLevel = 4
     origTechLevel = 4
     engineType = L
-    origMass = 0.24
+    origMass = 0.258
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 190
-      heatProduction = 172
+      maxThrust = 210
+      heatProduction = 175
       PROPELLANT
       {
         name = Kerosene
@@ -1431,7 +1431,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.9
+          amount = 2.1
         }
       }
 
@@ -1439,8 +1439,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 143
-      heatProduction = 172
+      maxThrust = 158
+      heatProduction = 175
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1465,7 +1465,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.9
+          amount = 2.1
         }
       }
 
@@ -1473,8 +1473,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 190
-      heatProduction = 172
+      maxThrust = 210
+      heatProduction = 175
       PROPELLANT
       {
         name = Aerozine50
@@ -1499,7 +1499,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.9
+          amount = 2.1
         }
       }
 
@@ -1516,7 +1516,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 1.9
+      amount = 2.1
     }
   }
 
@@ -1525,16 +1525,16 @@
 @PART[FASAApolloLFEF1]:FOR[RealFuels_StockEngines] //Saturn F1 Engine
 {
 
-  @mass = 1.8
-  @cost = 5129
-  %entryCost = 25645
-  @maxTemp = 2383
+  @mass = 2.03
+  @cost = 5595
+  %entryCost = 27975
+  @maxTemp = 2353
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 1650
-    @heatProduction = 182
+    @maxThrust = 1800
+    @heatProduction = 179
     @atmosphereCurve
     {
       @key,0 = 0 332
@@ -1563,15 +1563,15 @@
     techLevel = 6
     origTechLevel = 6
     engineType = L
-    origMass = 1.8
+    origMass = 2.03
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 1650
-      heatProduction = 182
+      maxThrust = 1800
+      heatProduction = 179
       PROPELLANT
       {
         name = Kerosene
@@ -1596,7 +1596,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 16.5
+          amount = 18
         }
       }
 
@@ -1604,8 +1604,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 1238
-      heatProduction = 182
+      maxThrust = 1350
+      heatProduction = 179
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1630,7 +1630,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 16.5
+          amount = 18
         }
       }
 
@@ -1638,8 +1638,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 1650
-      heatProduction = 182
+      maxThrust = 1800
+      heatProduction = 179
       PROPELLANT
       {
         name = Aerozine50
@@ -1664,7 +1664,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 16.5
+          amount = 18
         }
       }
 
@@ -1681,7 +1681,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 16.5
+      amount = 18
     }
   }
 
@@ -1690,16 +1690,16 @@
 @PART[FASAApolloLFERL10]:FOR[RealFuels_StockEngines] //RL-10 Engine
 {
 
-  @mass = 0.2
-  @cost = 324
-  %entryCost = 1620
-  @maxTemp = 1542
+  @mass = 0.26
+  @cost = 360
+  %entryCost = 1800
+  @maxTemp = 1478
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 86
-    @heatProduction = 102
+    @maxThrust = 98
+    @heatProduction = 96
     @atmosphereCurve
     {
       @key,0 = 0 442
@@ -1728,15 +1728,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = U+
-    origMass = 0.2
+    origMass = 0.26
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 86
-      heatProduction = 102
+      maxThrust = 98
+      heatProduction = 96
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1761,7 +1761,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.15
+          amount = 1.3
         }
       }
 
@@ -1769,8 +1769,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 115
-      heatProduction = 102
+      maxThrust = 130
+      heatProduction = 96
       PROPELLANT
       {
         name = Aerozine50
@@ -1795,7 +1795,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.15
+          amount = 1.3
         }
       }
 
@@ -1812,7 +1812,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 1.15
+      amount = 1.3
     }
   }
 
@@ -1821,16 +1821,16 @@
 @PART[FASAApolloLFEM1]:FOR[RealFuels_StockEngines] //Nova M1 Engine
 {
 
-  @mass = 2.4
-  @cost = 5320
-  %entryCost = 26600
-  @maxTemp = 1998
+  @mass = 2.689
+  @cost = 5819
+  %entryCost = 29095
+  @maxTemp = 1981
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 1200
-    @heatProduction = 142
+    @maxThrust = 1313
+    @heatProduction = 140
     @atmosphereCurve
     {
       @key,0 = 0 455
@@ -1859,15 +1859,15 @@
     techLevel = 7
     origTechLevel = 7
     engineType = U
-    origMass = 2.4
+    origMass = 2.689
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 1200
-      heatProduction = 142
+      maxThrust = 1313
+      heatProduction = 140
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1892,7 +1892,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 16
+          amount = 17.5
         }
       }
 
@@ -1900,8 +1900,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 1600
-      heatProduction = 142
+      maxThrust = 1750
+      heatProduction = 140
       PROPELLANT
       {
         name = Aerozine50
@@ -1919,14 +1919,14 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 16
+          amount = 17.5
         }
       }
 
@@ -1943,7 +1943,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 16
+      amount = 17.5
     }
   }
 
@@ -2050,7 +2050,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -2457,16 +2457,16 @@
 @PART[FASAGeminiLR87Twin]:FOR[RealFuels_StockEngines] //Titan LR-87
 {
 
-  @mass = 1.13
-  @cost = 2371
-  %entryCost = 11855
-  @maxTemp = 2227
+  @mass = 1.23
+  @cost = 2624
+  %entryCost = 13120
+  @maxTemp = 2244
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 900
-    @heatProduction = 173
+    @maxThrust = 1000
+    @heatProduction = 174
     @atmosphereCurve
     {
       @key,0 = 0 304
@@ -2495,15 +2495,15 @@
     techLevel = 4
     origTechLevel = 4
     engineType = L
-    origMass = 1.13
+    origMass = 1.23
     configuration = Aerozine50+NTO
     modded = false
 
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 900
-      heatProduction = 173
+      maxThrust = 1000
+      heatProduction = 174
       PROPELLANT
       {
         name = Aerozine50
@@ -2528,7 +2528,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 9
+          amount = 10
         }
       }
 
@@ -2536,8 +2536,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 900
-      heatProduction = 173
+      maxThrust = 1000
+      heatProduction = 174
       PROPELLANT
       {
         name = Kerosene
@@ -2562,7 +2562,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 9
+          amount = 10
         }
       }
 
@@ -2570,8 +2570,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 675
-      heatProduction = 173
+      maxThrust = 750
+      heatProduction = 174
       PROPELLANT
       {
         name = LqdHydrogen
@@ -2596,7 +2596,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 9
+          amount = 10
         }
       }
 
@@ -2613,7 +2613,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 9
+      amount = 10
     }
   }
 
@@ -2622,16 +2622,16 @@
 @PART[FASAGeminiLR91]:FOR[RealFuels_StockEngines] //Titan LR-91
 {
 
-  @mass = 0.557
-  @cost = 847
-  %entryCost = 4235
-  @maxTemp = 1850
+  @mass = 0.622
+  @cost = 963
+  %entryCost = 4815
+  @maxTemp = 1871
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 325
-    @heatProduction = 133
+    @maxThrust = 375
+    @heatProduction = 135
     @atmosphereCurve
     {
       @key,0 = 0 318
@@ -2660,15 +2660,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = U
-    origMass = 0.557
+    origMass = 0.622
     configuration = Aerozine50+NTO
     modded = false
 
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 325
-      heatProduction = 133
+      maxThrust = 375
+      heatProduction = 135
       PROPELLANT
       {
         name = Aerozine50
@@ -2686,14 +2686,14 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.25
+          amount = 3.75
         }
       }
 
@@ -2701,8 +2701,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 325
-      heatProduction = 133
+      maxThrust = 375
+      heatProduction = 135
       PROPELLANT
       {
         name = Kerosene
@@ -2727,7 +2727,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.25
+          amount = 3.75
         }
       }
 
@@ -2735,8 +2735,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 244
-      heatProduction = 133
+      maxThrust = 281
+      heatProduction = 135
       PROPELLANT
       {
         name = LqdHydrogen
@@ -2761,7 +2761,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.25
+          amount = 3.75
         }
       }
 
@@ -2771,14 +2771,14 @@
   MODULE
   {
     name = ModuleEngineIgnitor
-    ignitionsAvailable = 1
+    ignitionsAvailable = 4
     autoIgnitionTemperature = 800
     ignitorType = Electric
     useUllageSimulation = true
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 3.25
+      amount = 3.75
     }
   }
 
@@ -2787,16 +2787,16 @@
 @PART[FASAMercuryAtlasEng]:FOR[RealFuels_StockEngines] //Mercury Atlas Engine
 {
 
-  @mass = 0.37
-  @cost = 669
-  %entryCost = 3345
-  @maxTemp = 2114
+  @mass = 0.4
+  @cost = 723
+  %entryCost = 3615
+  @maxTemp = 2121
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 275
-    @heatProduction = 170
+    @maxThrust = 300
+    @heatProduction = 171
     @atmosphereCurve
     {
       @key,0 = 0 310
@@ -2825,15 +2825,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = L
-    origMass = 0.37
+    origMass = 0.4
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 275
-      heatProduction = 170
+      maxThrust = 300
+      heatProduction = 171
       PROPELLANT
       {
         name = Kerosene
@@ -2858,7 +2858,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 2.75
+          amount = 3
         }
       }
 
@@ -2875,7 +2875,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 2.75
+      amount = 3
     }
   }
 

--- a/GameData/RealFuels/Stockalike_FASA.cfg
+++ b/GameData/RealFuels/Stockalike_FASA.cfg
@@ -1,3 +1,5 @@
+//added Apollo CSM and LEM engines
+
 @PART[FASAAgena_Engine]:FOR[RealFuels_StockEngines] //Agena Rocket Engine
 {
 
@@ -602,7 +604,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 4
+        ignitionsAvailable = 1
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -687,7 +689,7 @@
   MODULE
   {
     name = ModuleEngineIgnitor
-    ignitionsAvailable = 4
+    ignitionsAvailable = 1
     autoIgnitionTemperature = 800
     ignitorType = Electric
     useUllageSimulation = true
@@ -966,7 +968,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 4
+        ignitionsAvailable = 1
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -1130,16 +1132,16 @@
 @PART[FASA_Mercury_Redstone_Eng]:FOR[RealFuels_StockEngines] //Mercury Redstone
 {
 
-  @mass = 0.336
-  @cost = 260
-  %entryCost = 1300
-  @maxTemp = 1847
+  @mass = 0.32
+  @cost = 248
+  %entryCost = 1240
+  @maxTemp = 1834
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 143
-    @heatProduction = 149
+    @maxThrust = 133
+    @heatProduction = 147
     @atmosphereCurve
     {
       @key,0 = 0 263
@@ -1168,15 +1170,15 @@
     techLevel = 1
     origTechLevel = 1
     engineType = L+
-    origMass = 0.336
+    origMass = 0.32
     configuration = Ethanol75+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Ethanol75+LqdOxygen
-      maxThrust = 143
-      heatProduction = 149
+      maxThrust = 133
+      heatProduction = 147
       PROPELLANT
       {
         name = Ethanol75
@@ -1201,7 +1203,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.5
+          amount = 1.4
         }
       }
 
@@ -1218,7 +1220,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 1.5
+      amount = 1.4
     }
   }
 
@@ -1227,16 +1229,16 @@
 @PART[FASAApolloLFEJ2]:FOR[RealFuels_StockEngines] //Saturn J2 Engine
 {
 
-  @mass = 0.821
-  @cost = 1456
-  %entryCost = 7280
-  @maxTemp = 1960
+  @mass = 0.75
+  @cost = 1312
+  %entryCost = 6560
+  @maxTemp = 1946
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 356
-    @heatProduction = 139
+    @maxThrust = 319
+    @heatProduction = 138
     @atmosphereCurve
     {
       @key,0 = 0 443
@@ -1265,15 +1267,15 @@
     techLevel = 5
     origTechLevel = 5
     engineType = U
-    origMass = 0.821
+    origMass = 0.75
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 356
-      heatProduction = 139
+      maxThrust = 319
+      heatProduction = 138
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1298,7 +1300,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 4.75
+          amount = 4.25
         }
       }
 
@@ -1306,8 +1308,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 475
-      heatProduction = 139
+      maxThrust = 425
+      heatProduction = 138
       PROPELLANT
       {
         name = Kerosene
@@ -1332,7 +1334,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 4.75
+          amount = 4.25
         }
       }
 
@@ -1349,7 +1351,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 4.75
+      amount = 4.25
     }
   }
 
@@ -1358,16 +1360,16 @@
 @PART[FASAApolloLFEH1]:FOR[RealFuels_StockEngines] //Saturn H-1 Engine
 {
 
-  @mass = 0.258
-  @cost = 610
-  %entryCost = 3050
-  @maxTemp = 2245
+  @mass = 0.24
+  @cost = 560
+  %entryCost = 2800
+  @maxTemp = 2222
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 210
-    @heatProduction = 175
+    @maxThrust = 190
+    @heatProduction = 172
     @atmosphereCurve
     {
       @key,0 = 0 320
@@ -1396,15 +1398,15 @@
     techLevel = 4
     origTechLevel = 4
     engineType = L
-    origMass = 0.258
+    origMass = 0.24
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 210
-      heatProduction = 175
+      maxThrust = 190
+      heatProduction = 172
       PROPELLANT
       {
         name = Kerosene
@@ -1429,7 +1431,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 2.1
+          amount = 1.9
         }
       }
 
@@ -1437,8 +1439,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 158
-      heatProduction = 175
+      maxThrust = 143
+      heatProduction = 172
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1463,7 +1465,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 2.1
+          amount = 1.9
         }
       }
 
@@ -1471,8 +1473,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 210
-      heatProduction = 175
+      maxThrust = 190
+      heatProduction = 172
       PROPELLANT
       {
         name = Aerozine50
@@ -1497,7 +1499,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 2.1
+          amount = 1.9
         }
       }
 
@@ -1514,7 +1516,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 2.1
+      amount = 1.9
     }
   }
 
@@ -1523,16 +1525,16 @@
 @PART[FASAApolloLFEF1]:FOR[RealFuels_StockEngines] //Saturn F1 Engine
 {
 
-  @mass = 2.03
-  @cost = 5595
-  %entryCost = 27975
-  @maxTemp = 2353
+  @mass = 1.8
+  @cost = 5129
+  %entryCost = 25645
+  @maxTemp = 2383
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 1800
-    @heatProduction = 179
+    @maxThrust = 1650
+    @heatProduction = 182
     @atmosphereCurve
     {
       @key,0 = 0 332
@@ -1561,15 +1563,15 @@
     techLevel = 6
     origTechLevel = 6
     engineType = L
-    origMass = 2.03
+    origMass = 1.8
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 1800
-      heatProduction = 179
+      maxThrust = 1650
+      heatProduction = 182
       PROPELLANT
       {
         name = Kerosene
@@ -1594,7 +1596,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 18
+          amount = 16.5
         }
       }
 
@@ -1602,8 +1604,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 1350
-      heatProduction = 179
+      maxThrust = 1238
+      heatProduction = 182
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1628,7 +1630,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 18
+          amount = 16.5
         }
       }
 
@@ -1636,8 +1638,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 1800
-      heatProduction = 179
+      maxThrust = 1650
+      heatProduction = 182
       PROPELLANT
       {
         name = Aerozine50
@@ -1662,7 +1664,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 18
+          amount = 16.5
         }
       }
 
@@ -1679,7 +1681,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 18
+      amount = 16.5
     }
   }
 
@@ -1688,16 +1690,16 @@
 @PART[FASAApolloLFERL10]:FOR[RealFuels_StockEngines] //RL-10 Engine
 {
 
-  @mass = 0.26
-  @cost = 360
-  %entryCost = 1800
-  @maxTemp = 1478
+  @mass = 0.2
+  @cost = 324
+  %entryCost = 1620
+  @maxTemp = 1542
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 98
-    @heatProduction = 96
+    @maxThrust = 86
+    @heatProduction = 102
     @atmosphereCurve
     {
       @key,0 = 0 442
@@ -1726,15 +1728,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = U+
-    origMass = 0.26
+    origMass = 0.2
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 98
-      heatProduction = 96
+      maxThrust = 86
+      heatProduction = 102
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1759,7 +1761,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.3
+          amount = 1.15
         }
       }
 
@@ -1767,8 +1769,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 130
-      heatProduction = 96
+      maxThrust = 115
+      heatProduction = 102
       PROPELLANT
       {
         name = Aerozine50
@@ -1793,7 +1795,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 1.3
+          amount = 1.15
         }
       }
 
@@ -1810,7 +1812,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 1.3
+      amount = 1.15
     }
   }
 
@@ -1819,16 +1821,16 @@
 @PART[FASAApolloLFEM1]:FOR[RealFuels_StockEngines] //Nova M1 Engine
 {
 
-  @mass = 2.689
-  @cost = 5819
-  %entryCost = 29095
-  @maxTemp = 1981
+  @mass = 2.4
+  @cost = 5320
+  %entryCost = 26600
+  @maxTemp = 1998
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 1313
-    @heatProduction = 140
+    @maxThrust = 1200
+    @heatProduction = 142
     @atmosphereCurve
     {
       @key,0 = 0 455
@@ -1857,15 +1859,15 @@
     techLevel = 7
     origTechLevel = 7
     engineType = U
-    origMass = 2.689
+    origMass = 2.4
     configuration = LqdHydrogen+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 1313
-      heatProduction = 140
+      maxThrust = 1200
+      heatProduction = 142
       PROPELLANT
       {
         name = LqdHydrogen
@@ -1890,7 +1892,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 17.5
+          amount = 16
         }
       }
 
@@ -1898,8 +1900,8 @@
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 1750
-      heatProduction = 140
+      maxThrust = 1600
+      heatProduction = 142
       PROPELLANT
       {
         name = Aerozine50
@@ -1917,14 +1919,14 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 4
+        ignitionsAvailable = 1
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 17.5
+          amount = 16
         }
       }
 
@@ -1941,7 +1943,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 17.5
+      amount = 16
     }
   }
 
@@ -2048,7 +2050,7 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 4
+        ignitionsAvailable = 1
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
@@ -2455,16 +2457,16 @@
 @PART[FASAGeminiLR87Twin]:FOR[RealFuels_StockEngines] //Titan LR-87
 {
 
-  @mass = 1.23
-  @cost = 2624
-  %entryCost = 13120
-  @maxTemp = 2244
+  @mass = 1.13
+  @cost = 2371
+  %entryCost = 11855
+  @maxTemp = 2227
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 1000
-    @heatProduction = 174
+    @maxThrust = 900
+    @heatProduction = 173
     @atmosphereCurve
     {
       @key,0 = 0 304
@@ -2493,15 +2495,15 @@
     techLevel = 4
     origTechLevel = 4
     engineType = L
-    origMass = 1.23
+    origMass = 1.13
     configuration = Aerozine50+NTO
     modded = false
 
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 1000
-      heatProduction = 174
+      maxThrust = 900
+      heatProduction = 173
       PROPELLANT
       {
         name = Aerozine50
@@ -2526,7 +2528,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 10
+          amount = 9
         }
       }
 
@@ -2534,8 +2536,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 1000
-      heatProduction = 174
+      maxThrust = 900
+      heatProduction = 173
       PROPELLANT
       {
         name = Kerosene
@@ -2560,7 +2562,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 10
+          amount = 9
         }
       }
 
@@ -2568,8 +2570,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 750
-      heatProduction = 174
+      maxThrust = 675
+      heatProduction = 173
       PROPELLANT
       {
         name = LqdHydrogen
@@ -2594,7 +2596,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 10
+          amount = 9
         }
       }
 
@@ -2611,7 +2613,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 10
+      amount = 9
     }
   }
 
@@ -2620,16 +2622,16 @@
 @PART[FASAGeminiLR91]:FOR[RealFuels_StockEngines] //Titan LR-91
 {
 
-  @mass = 0.622
-  @cost = 963
-  %entryCost = 4815
-  @maxTemp = 1871
+  @mass = 0.557
+  @cost = 847
+  %entryCost = 4235
+  @maxTemp = 1850
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 375
-    @heatProduction = 135
+    @maxThrust = 325
+    @heatProduction = 133
     @atmosphereCurve
     {
       @key,0 = 0 318
@@ -2658,15 +2660,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = U
-    origMass = 0.622
+    origMass = 0.557
     configuration = Aerozine50+NTO
     modded = false
 
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 375
-      heatProduction = 135
+      maxThrust = 325
+      heatProduction = 133
       PROPELLANT
       {
         name = Aerozine50
@@ -2684,14 +2686,14 @@
       MODULE
       {
         name = ModuleEngineIgnitor
-        ignitionsAvailable = 4
+        ignitionsAvailable = 1
         autoIgnitionTemperature = 800
         ignitorType = Electric
         useUllageSimulation = true
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.75
+          amount = 3.25
         }
       }
 
@@ -2699,8 +2701,8 @@
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 375
-      heatProduction = 135
+      maxThrust = 325
+      heatProduction = 133
       PROPELLANT
       {
         name = Kerosene
@@ -2725,7 +2727,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.75
+          amount = 3.25
         }
       }
 
@@ -2733,8 +2735,8 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 281
-      heatProduction = 135
+      maxThrust = 244
+      heatProduction = 133
       PROPELLANT
       {
         name = LqdHydrogen
@@ -2759,7 +2761,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3.75
+          amount = 3.25
         }
       }
 
@@ -2769,14 +2771,14 @@
   MODULE
   {
     name = ModuleEngineIgnitor
-    ignitionsAvailable = 4
+    ignitionsAvailable = 1
     autoIgnitionTemperature = 800
     ignitorType = Electric
     useUllageSimulation = true
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 3.75
+      amount = 3.25
     }
   }
 
@@ -2785,16 +2787,16 @@
 @PART[FASAMercuryAtlasEng]:FOR[RealFuels_StockEngines] //Mercury Atlas Engine
 {
 
-  @mass = 0.4
-  @cost = 723
-  %entryCost = 3615
-  @maxTemp = 2121
+  @mass = 0.37
+  @cost = 669
+  %entryCost = 3345
+  @maxTemp = 2114
 
 
   @MODULE[ModuleEngines]
   {
-    @maxThrust = 300
-    @heatProduction = 171
+    @maxThrust = 275
+    @heatProduction = 170
     @atmosphereCurve
     {
       @key,0 = 0 310
@@ -2823,15 +2825,15 @@
     techLevel = 3
     origTechLevel = 3
     engineType = L
-    origMass = 0.4
+    origMass = 0.37
     configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 300
-      heatProduction = 171
+      maxThrust = 275
+      heatProduction = 170
       PROPELLANT
       {
         name = Kerosene
@@ -2856,7 +2858,7 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 3
+          amount = 2.75
         }
       }
 
@@ -2873,7 +2875,7 @@
     IGNITOR_RESOURCE
     {
       name = ElectricCharge
-      amount = 3
+      amount = 2.75
     }
   }
 
@@ -3859,4 +3861,205 @@
   }
 
 
+}
+@PART[FASAApollo_SM_Engine]:FOR[RealFuels_StockEngines] //Apollo CSM engine
+{
+  @title = Apollo CSM engine
+  @mass = 0.385
+  @cost = 348
+  %entryCost = 1740
+  @maxTemp = 1484
+  @description = Engine for the Apollo CSM.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 124
+    @heatProduction = 94
+    @atmosphereCurve
+    {
+      @key,0 = 0 325
+      @key,1 = 1 115
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.3853
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 124
+      heatProduction = 94
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 24
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.24
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.24
+    }
+  }
+  
+  
+}
+@PART[FASALM_DescentEngine]:FOR[RealFuels_StockEngines] //Apollo LEM Descent Engine
+{
+  @title = Apollo LEM Descent Engine
+  @mass = 0.14
+  @cost = 178
+  %entryCost = 890
+  @maxTemp = 1484
+  @description = Specificity made for landing the LEM on the Mun safely.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 45
+    @heatProduction = 94
+    @atmosphereCurve
+    {
+      @key,0 = 0 325
+      @key,1 = 1 115
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 0.5
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.1398
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 45
+      heatProduction = 94
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 24
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.45
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.45
+    }
+  }
+  
+  
 }

--- a/GameData/RealFuels/Stockalike_KSOS.cfg~
+++ b/GameData/RealFuels/Stockalike_KSOS.cfg~
@@ -1,273 +1,3 @@
-//For helldiver's Kerbin Shuttle Orbiter System
-
-@PART[super25enginekso]:FOR[RealFuels_StockEngines] //Thrustmax 300
-{
-  @title = Thrustmax 300
-  @mass = 0.566
-  @cost = 540
-  %entryCost = 2700
-  @maxTemp = 2400
-  @description = Latest engine from the makers of the 200 series. The Thrustmax 300 features digitally controlled gimbling, electronic fuel injection, flame out recovery, and their patented 'Cyromax" nozzle cooling system.
-  
-  @MODULE[ModuleEnginesFX]
-  {
-    @maxThrust = 290
-    @heatProduction = 195
-    @atmosphereCurve
-    {
-      @key,0 = 0 274
-      @key,1 = 1 337
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = Kerosene
-      ratio = 37.694087
-      DrawGauge = True
-    }
-    PROPELLANT
-    {
-      name = LqdOxygen
-      ratio = 62.305913
-    }
-  }
-  
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesFX
-    techLevel = 6
-    origTechLevel = 6
-    engineType = L+
-    origMass = 0.566
-    configuration = Kerosene+LqdOxygen
-    modded = false
-    
-    CONFIG
-    {
-      name = Kerosene+LqdOxygen
-      maxThrust = 290
-      heatProduction = 195
-      PROPELLANT
-      {
-        name = Kerosene
-        ratio = 37.69408655434424
-        DrawGauge = True
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 62.30591344565576
-      }
-      IspSL = 1.2000
-      IspV = 0.8000
-      throttle = 0.6
-      MODULE
-      {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2.9
-        }
-      }
-      
-      
-    }
-    CONFIG
-    {
-      name = LqdHydrogen+LqdOxygen
-      maxThrust = 218
-      heatProduction = 195
-      PROPELLANT
-      {
-        name = LqdHydrogen
-        ratio = 76.30830964721619
-        DrawGauge = True
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 23.69169035278381
-      }
-      IspSL = 1.5600
-      IspV = 1.0160
-      throttle = 0.6
-      MODULE
-      {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2.9
-        }
-      }
-      
-      
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  MODULE
-  {
-    name = ModuleEngineIgnitor
-    ignitionsAvailable = 1
-    autoIgnitionTemperature = 800
-    ignitorType = Electric
-    useUllageSimulation = true
-    IGNITOR_RESOURCE
-    {
-      name = ElectricCharge
-      amount = 2.9
-    }
-  }
-  
-  
-}
-
-@PART[thrustmaxkso]:FOR[RealFuels_StockEngines] //Thrustmax 200
-{
-  @title = Thrustmax 200
-  @mass = 0.405
-  @cost = 371
-  %entryCost = 1855
-  @maxTemp = 2400
-  @description = Much more powerful than their 100 series, the Thrustmax 200 has a high thrust to weight ratio while in atmosphere but loses out to more efficient engines whilst in a vacuum.
-  
-  @MODULE[ModuleEnginesFX]
-  {
-    @maxThrust = 200
-    @heatProduction = 193
-    @atmosphereCurve
-    {
-      @key,0 = 0 270
-      @key,1 = 1 332
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = Kerosene
-      ratio = 37.694087
-      DrawGauge = True
-    }
-    PROPELLANT
-    {
-      name = LqdOxygen
-      ratio = 62.305913
-    }
-  }
-  
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesFX
-    techLevel = 5
-    origTechLevel = 5
-    engineType = L+
-    origMass = 0.405
-    configuration = Kerosene+LqdOxygen
-    modded = false
-    
-    CONFIG
-    {
-      name = Kerosene+LqdOxygen
-      maxThrust = 200
-      heatProduction = 193
-      PROPELLANT
-      {
-        name = Kerosene
-        ratio = 37.69408655434424
-        DrawGauge = True
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 62.30591344565576
-      }
-      IspSL = 1.2000
-      IspV = 0.8000
-      throttle = 0.65
-      MODULE
-      {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2
-        }
-      }
-      
-      
-    }
-    CONFIG
-    {
-      name = LqdHydrogen+LqdOxygen
-      maxThrust = 150
-      heatProduction = 193
-      PROPELLANT
-      {
-        name = LqdHydrogen
-        ratio = 76.30830964721619
-        DrawGauge = True
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 23.69169035278381
-      }
-      IspSL = 1.5600
-      IspV = 1.0160
-      throttle = 0.65
-      MODULE
-      {
-        name = ModuleEngineIgnitor
-        ignitionsAvailable = 1
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2
-        }
-      }
-      
-      
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  MODULE
-  {
-    name = ModuleEngineIgnitor
-    ignitionsAvailable = 1
-    autoIgnitionTemperature = 800
-    ignitorType = Electric
-    useUllageSimulation = true
-    IGNITOR_RESOURCE
-    {
-      name = ElectricCharge
-      amount = 2
-    }
-  }
-  
-  
-}
-
 @PART[omskso]:FOR[RealFuels_StockEngines] //Omnimax 40T
 {
   @title = Omnimax 40T
@@ -348,6 +78,41 @@
       
       
     }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 40
+      heatProduction = 158
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 50.36645941158081
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.63354058841919
+      }
+      IspSL = 0.8640
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+      
+    }
   }
   !MODULE[ModuleEngineIgnitor] {}
   MODULE
@@ -361,6 +126,272 @@
     {
       name = ElectricCharge
       amount = 0.4
+    }
+  }
+  
+  
+}
+@PART[super25enginekso]:FOR[RealFuels_StockEngines] //Thrustmax 300
+{
+  @title = Thrustmax 300
+  @mass = 0.382
+  @cost = 1031
+  %entryCost = 5155
+  @maxTemp = 2276
+  @description = Latest engine from the makers of the 200 series. The Thrustmax 300 features digitally controlled gimbling, electronic fuel injection, flame out recovery, and their patented 'Cyromax" nozzle cooling system.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 218
+    @heatProduction = 171
+    @atmosphereCurve
+    {
+      @key,0 = 0 434
+      @key,1 = 1 365
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 76.308310
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 23.691690
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L+
+    origMass = 0.382
+    configuration = LqdHydrogen+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 218
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0.6
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.9
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 290
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0.6
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.9
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 2.9
+    }
+  }
+  
+  
+}
+@PART[thrustmaxkso]:FOR[RealFuels_StockEngines] //Thrustmax 200
+{
+  @title = Thrustmax 200
+  @mass = 0.275
+  @cost = 690
+  %entryCost = 3450
+  @maxTemp = 2238
+  @description = Much more powerful than their 100 series, the Thrustmax 200 has a high thrust to weight ratio while in atmosphere but loses out to more efficient engines whilst in a vacuum.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 150
+    @heatProduction = 169
+    @atmosphereCurve
+    {
+      @key,0 = 0 428
+      @key,1 = 1 360
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 76.308310
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 23.691690
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 5
+    origTechLevel = 5
+    engineType = L+
+    origMass = 0.275
+    configuration = LqdHydrogen+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 150
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 200
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 2
     }
   }
   

--- a/GameData/RealFuels/Stockalike_NovaPunch.cfg
+++ b/GameData/RealFuels/Stockalike_NovaPunch.cfg
@@ -1,3 +1,5 @@
+//added M50 engine
+
 @PART[NP_aux_radialliquidbooster]:FOR[RealFuels_StockEngines] //NP Radial LB
 {
 
@@ -7692,4 +7694,137 @@
   }
 
 
+}
+@PART[NP_lfe_2_5m_m50engine]:FOR[RealFuels_StockEngines] //M50 Main rocket Engine
+{
+  @title = M50 Main rocket Engine
+  @mass = 2.917
+  @cost = 4316
+  %entryCost = 21580
+  @maxTemp = 2228
+  @description = The venerable ancient king of rocket engines, the M50 has been powering super-heavy rockets for what seems like an eternity. Keep away from children and small animals.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 1800
+    @heatProduction = 173
+    @atmosphereCurve
+    {
+      @key,0 = 0 314
+      @key,1 = 1 285
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 4
+    origTechLevel = 4
+    engineType = L+
+    origMass = 2.917
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 1800
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 0.9510
+      throttle = 0.7
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 18
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1350
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.2078
+      throttle = 0.7
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 18
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 18
+    }
+  }
+  
+  
 }

--- a/GameData/RealFuels/Stockalike_OPT.cfg
+++ b/GameData/RealFuels/Stockalike_OPT.cfg
@@ -1,0 +1,136 @@
+//For K.Yeon's OPT Space Plane Parts
+
+@PART[j_linear_aerospike]:FOR[RealFuels_StockEngines] //OPT Linear Aerospike Rocket
+{
+  @title = OPT Linear Aerospike Rocket
+  @mass = 5.94
+  @cost = 5856
+  %entryCost = 29280
+  @maxTemp = 2400
+  @description = An extremely powerful aerospike style rocket for an OPT fuselage. When advertising its capabilities, OPT stressed that it wasn't all about the small print, and that we should just focus on how cool it was. The small print, coincidentally, reads "CAUTION: liable to overheat."
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 656
+    @heatProduction = 198
+    @atmosphereCurve
+    {
+      @key,0 = 0 489
+      @key,1 = 1 450
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 76.308310
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 23.691690
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = A
+    origMass = 5.94
+    configuration = LqdHydrogen+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 656
+      heatProduction = 198
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4300
+      IspV = 1.3970
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 8.75
+        }
+      }
+      
+      
+    }
+  }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 875
+      heatProduction = 198
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.1000
+      IspV = 1.1000
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 8.75
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 8.75
+    }
+  }
+  
+  
+}

--- a/GameData/RealFuels/Stockalike_QuizTech.cfg
+++ b/GameData/RealFuels/Stockalike_QuizTech.cfg
@@ -1,0 +1,568 @@
+// For Quiznos323's QuizTech v1.2
+
+@PART[QT-S25]:FOR[RealFuels_StockEngines] //QT-S25 Launch System
+{
+  @title = QT-S25 Launch System
+  @mass = 2.913
+  @cost = 4296
+  %entryCost = 21480
+  @maxTemp = 2228
+  @description = The QT-S25 was designed as a first stage heavy lifter, and when our engineers realized that they forgot to install the gimbal, they put holes in the side to add moar engines! Use in conjunction with the patented QuizTech Attitude Control System Thruster for maximum stability.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 1800
+    @heatProduction = 173
+    @atmosphereCurve
+    {
+      @key,0 = 0 314
+      @key,1 = 1 285
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 4
+    origTechLevel = 4
+    engineType = L+
+    origMass = 2.913
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 1800
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 0.9500
+      throttle = 0.7
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 18
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1350
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.2065
+      throttle = 0.7
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 18
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 1800
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.97234359257053
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.02765640742947
+      }
+      IspSL = 1.0815
+      IspV = 0.9785
+      throttle = 0.7
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 18
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 18
+    }
+  }
+  
+  
+}
+
+@PART[QT-500]:FOR[RealFuels_StockEngines] //QT-500 Liquid Engine
+{
+  @title = QT-500 Liquid Engine
+  @mass = 0.665
+  @cost = 627
+  %entryCost = 3135
+  @maxTemp = 1509
+  @description = Our engineers thought that one nozzle was boring, so they added four more! This advance in engine technology also brings with it the option to switch between 5 or 1 active engine nozzles during flight. This can be handy when in need of precision over power.
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
+  {
+    @maxThrust = 185
+    @heatProduction = 99
+    @atmosphereCurve
+    {
+      @key,0 = 0 365
+      @key,1 = 1 128
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOnly]]
+  {
+    @maxThrust = 37
+    @heatProduction = 16
+    @atmosphereCurve
+    {
+      @key,0 = 0 406
+      @key,1 = 1 141
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleHybridEngine
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = U+
+    origMass = 0.665
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 185
+      heatProduction = 99
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 1.0500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.85
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 139
+      heatProduction = 99
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.3335
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.85
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 185
+      heatProduction = 99
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 1.0080
+      IspV = 0.9975
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.85
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.85
+    }
+  }
+  
+  
+}
+
+@PART[ACS]:FOR[RealFuels_StockEngines] //ACS Thruster
+{
+  @title = ACS Thruster
+  @mass = 0.112
+  @cost = 200
+  %entryCost = 1000
+  @maxTemp = 2105
+  @description = The Attitude Control System Thruster was designed to keep large rockets pointed up because, otherwise, no one goes to space. And not going to space makes for a very, very sad day.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 40
+    @heatProduction = 169
+    @atmosphereCurve
+    {
+      @key,0 = 0 335
+      @key,1 = 1 275
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = L+
+    origMass = 0.112
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 40
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 1.0500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 30
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.3335
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 40
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.0815
+      IspV = 1.0815
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 38
+      heatProduction = 169
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 0.9765
+      IspV = 0.9765
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.4
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.4
+    }
+  }
+  
+  
+}

--- a/GameData/RealFuels/Stockalike_RetroFuture.cfg
+++ b/GameData/RealFuels/Stockalike_RetroFuture.cfg
@@ -1,0 +1,904 @@
+//For NohArksPNP's RetroFuture pack 
+//Currently missing configs for VTOL engines
+
+@PART[rfAeroSpikeAdv]:FOR[RealFuels_StockEngines] //Aerospike
+{
+  @title = Aerospike
+  @mass = 0.699
+  @cost = 1014
+  %entryCost = 5070
+  @maxTemp = 2400
+  @description = Aerospike Engine. The round kind.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 180
+    @heatProduction = 192
+    @atmosphereCurve
+    {
+      @key,0 = 0 368
+      @key,1 = 1 331
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = A
+    origMass = 0.699
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 180
+      heatProduction = 192
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 1.0500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.8
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 135
+      heatProduction = 192
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.3335
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.8
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.8
+    }
+  }
+  
+  
+}
+
+@PART[rfLinearSpikeAdv]:FOR[RealFuels_StockEngines] //Linear Aerospike
+{
+  @title = Linear Aerospike
+  @mass = 1.22
+  @cost = 1264
+  %entryCost = 6320
+  @maxTemp = 2400
+  @description = Straight, no chaser.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 180
+    @heatProduction = 199
+    @atmosphereCurve
+    {
+      @key,0 = 0 385
+      @key,1 = 1 347
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = A
+    origMass = 1.22
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 180
+      heatProduction = 199
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.1000
+      IspV = 1.1000
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.8
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 135
+      heatProduction = 199
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4300
+      IspV = 1.3970
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 1.8
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 1.8
+    }
+  }
+  
+  
+}
+
+@PART[rfRadialSpike]:FOR[RealFuels_StockEngines] //Radial Aerospike
+{
+  @title = Radial Aerospike
+  @mass = 0.175
+  @cost = 310
+  %entryCost = 1550
+  @maxTemp = 2400
+  @description = Small radial mount auxiliary Aerospike Engine.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 45
+    @heatProduction = 192
+    @atmosphereCurve
+    {
+      @key,0 = 0 368
+      @key,1 = 1 331
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = A
+    origMass = 0.175
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 45
+      heatProduction = 192
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0500
+      IspV = 1.0500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.45
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 34
+      heatProduction = 192
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.3650
+      IspV = 1.3335
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.45
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.45
+    }
+  }
+  
+  
+}
+
+@PART[ED051]:FOR[RealFuels_StockEngines] //"Eddie" 06 LF/OX Engine
+{
+  @title = "Eddie" 06 LF/OX Engine
+  @mass = 0.197
+  @cost = 168
+  %entryCost = 840
+  @maxTemp = 1450
+  @description = Precision manufacturing techniques and advanced alloys allows for this half sized version of the original "Eddie" 125; perfect for probe sized applications. Inherited the same propensity for overheating but given it's size, not as serious of a problem.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 30
+    @heatProduction = 86
+    @atmosphereCurve
+    {
+      @key,0 = 0 263
+      @key,1 = 1 29
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100.000000
+      DrawGauge = True
+    }
+    
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 2
+    origTechLevel = 2
+    engineType = O
+    origMass = 0.197
+    configuration = Hydrazine
+    modded = false
+    
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 30
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.2466
+      IspV = 0.7920
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.3
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 30
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.8640
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.3
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 0
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.3
+    }
+  }
+  
+  
+}
+
+@PART[ED125]:FOR[RealFuels_StockEngines] //"Eddie" 125 LF/OX Engine
+{
+  @title = "Eddie" 125 LF/OX Engine
+  @mass = 0.333
+  @cost = 265
+  %entryCost = 1325
+  @maxTemp = 1450
+  @description = An efficient, low profile, engine built around the Expansion Delfection Nozzel design. Perfect for Landers and numerous other uses. Prone to overheating, possibly damaging adjacent parts.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 55
+    @heatProduction = 88
+    @atmosphereCurve
+    {
+      @key,0 = 0 271
+      @key,1 = 1 30
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100.000000
+      DrawGauge = True
+    }
+    
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.333
+    configuration = Hydrazine
+    modded = false
+    
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 55
+      heatProduction = 88
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.2466
+      IspV = 0.7920
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.55
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 55
+      heatProduction = 88
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.8640
+      IspV = 1.0450
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.55
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 0
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 0.55
+    }
+  }
+  
+  
+}
+
+@PART[ED250]:FOR[RealFuels_StockEngines] //"Eddie" 250 LF/OX Engine
+{
+  @title = "Eddie" 250 LF/OX Engine
+  @mass = 1.535
+  @cost = 988
+  %entryCost = 4940
+  @maxTemp = 1450
+  @description = 2.5m diameter seemed the perfect next step for the line of "Eddie" engines. Besides the propensity to overheat, this capable mid-sized engine poses direct competition to the popular "Poodles" engine produced by Rockomax.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 225
+    @heatProduction = 86
+    @atmosphereCurve
+    {
+      @key,0 = 0 281
+      @key,1 = 1 29
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100.000000
+      DrawGauge = True
+    }
+    
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 4
+    origTechLevel = 4
+    engineType = O
+    origMass = 1.535
+    configuration = Hydrazine
+    modded = false
+    
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 225
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.2398
+      IspV = 0.8100
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.25
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 225
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.8400
+      IspV = 1.0687
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.25
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 0
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 2.25
+    }
+  }
+  
+  
+}
+
+@PART[ED399]:FOR[RealFuels_StockEngines] //"Eddie" 399 LF/OX Engine
+{
+  @title = "Eddie" 399 LF/OX Engine
+  @mass = 3.044
+  @cost = 1962
+  %entryCost = 9810
+  @maxTemp = 1450
+  @description = 2.5m diameter seemed the perfect next step for the line of "Eddie" engines. Besides the propensity to overheat, this capable mid-sized engine poses direct competition to the popular "Poodles" engine produced by Rockomax.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 399
+    @heatProduction = 86
+    @atmosphereCurve
+    {
+      @key,0 = 0 291
+      @key,1 = 1 29
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Hydrazine
+      ratio = 100.000000
+      DrawGauge = True
+    }
+    
+  }
+  
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    techLevel = 5
+    origTechLevel = 5
+    engineType = O
+    origMass = 3.044
+    configuration = Hydrazine
+    modded = false
+    
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 399
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.2329
+      IspV = 0.8280
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.99
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 399
+      heatProduction = 86
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.8160
+      IspV = 1.0925
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.99
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 0
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.99
+    }
+  }
+  
+  
+}

--- a/GameData/RealFuels/Stockalike_SpaceY.cfg
+++ b/GameData/RealFuels/Stockalike_SpaceY.cfg
@@ -1,3 +1,5 @@
+//added multimode support for R5, M5, and M9 engines
+
 @PART[SYengine1mD1]:FOR[RealFuels_StockEngines] //SpaceY K1 “Kiwi” Engine
 {
 
@@ -171,9 +173,8 @@
   %entryCost = 108180
   @maxTemp = 2394
 
-  !MODULE[ModuleHybridEngine]{}
-  !MODULE[ModuleEnginesFX],1{}
-  @MODULE[ModuleEnginesFX]
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
     @maxThrust = 4400
     @heatProduction = 181
@@ -181,6 +182,30 @@
     {
       @key,0 = 0 382
       @key,1 = 1 314
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdMethane
+      ratio = 43.546793
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 56.453207
+    }
+  }
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOff]]
+  {
+    @maxThrust = 3520
+    @heatProduction = 181
+    @atmosphereCurve
+    {
+      @key,0 = 0 420
+      @key,1 = 1 345
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -337,9 +362,8 @@
   %entryCost = 200950
   @maxTemp = 2394
 
-  !MODULE[ModuleHybridEngine]{}
-  !MODULE[ModuleEnginesFX],1{}
-  @MODULE[ModuleEnginesFX]
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
     @maxThrust = 8200
     @heatProduction = 181
@@ -347,6 +371,30 @@
     {
       @key,0 = 0 382
       @key,1 = 1 314
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdMethane
+      ratio = 43.546793
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 56.453207
+    }
+  }
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOnly]]
+  {
+    @maxThrust = 1200
+    @heatProduction = 24
+    @atmosphereCurve
+    {
+      @key,0 = 0 420
+      @key,1 = 1 345
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -503,9 +551,8 @@
   %entryCost = 253300
   @maxTemp = 2400
 
-  !MODULE[ModuleHybridEngine]{}
-  !MODULE[ModuleEnginesFX],1{}
-  @MODULE[ModuleEnginesFX]
+
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
     @maxThrust = 11000
     @heatProduction = 190
@@ -513,6 +560,30 @@
     {
       @key,0 = 0 371
       @key,1 = 1 335
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdMethane
+      ratio = 43.546793
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 56.453207
+    }
+  }
+  @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOff]]
+  {
+    @maxThrust = 8800
+    @heatProduction = 190
+    @atmosphereCurve
+    {
+      @key,0 = 0 408
+      @key,1 = 1 369
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -1462,7 +1533,7 @@
         name = Aerozine50+NTO
         maxThrust = 65
         heatProduction = 95
-
+   
         PROPELLANT
         {
         name = Aerozine50
@@ -1641,7 +1712,7 @@
         name = Aerozine50+NTO
         maxThrust = 162.5
         heatProduction = 30
-
+   
         PROPELLANT
         {
         name = Aerozine50
@@ -1771,7 +1842,7 @@
     {
       name = Hydrazine
       thrusterPower = 8
-
+      
       PROPELLANT
       {
         name = Hydrazine
@@ -1780,5 +1851,5 @@
       IspSL = 0.23
       IspV = 0.72
     }
-  }
+  }    
 }

--- a/GameData/RealFuels/Stockalike_StarshineIndustries.cfg
+++ b/GameData/RealFuels/Stockalike_StarshineIndustries.cfg
@@ -1,0 +1,1066 @@
+//For ganinian's StarShine Industries
+
+@PART[merlin1D]:FOR[RealFuels_StockEngines] //Merlin 1D
+{
+  @title = Merlin 1D
+  @mass = 0.842
+  @cost = 164
+  %entryCost = 820
+  @maxTemp = 2400
+  @description = SpaceX FTW!
+  
+  @MODULE[ModuleEngines]
+  {
+    @maxThrust = 410
+    @heatProduction = 201
+    @atmosphereCurve
+    {
+      @key,0 = 0 165
+      @key,1 = 1 352
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1.5
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEngines
+    techLevel = 4
+    origTechLevel = 4
+    engineType = L+
+    origMass = 0.842
+    configuration = Kerosene+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 410
+      heatProduction = 201
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.3000
+      IspV = 0.5000
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.1
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 410
+      heatProduction = 201
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.3390
+      IspV = 0.5150
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.1
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 308
+      heatProduction = 201
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.6900
+      IspV = 0.6350
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.1
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 390
+      heatProduction = 201
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 1.2090
+      IspV = 0.4650
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.1
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 4.1
+    }
+  }
+  
+  
+}
+@PART[merlin1D_vac]:FOR[RealFuels_StockEngines] //Merlin 1D Vacuum
+{
+  @title = Merlin 1D Vacuum
+  @mass = 1.391
+  @cost = 2341
+  %entryCost = 11705
+  @maxTemp = 1563
+  @description = SpaceX FTW!
+  
+  @MODULE[ModuleEngines]
+  {
+    @maxThrust = 420
+    @heatProduction = 103
+    @atmosphereCurve
+    {
+      @key,0 = 0 376
+      @key,1 = 1 130
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1.2
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEngines
+    techLevel = 4
+    origTechLevel = 4
+    engineType = L+
+    origMass = 1.391
+    configuration = Aerozine50+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 420
+      heatProduction = 103
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.4800
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 420
+      heatProduction = 103
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.4800
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 420
+      heatProduction = 103
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 0.4750
+      IspV = 1.1400
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 420
+      heatProduction = 103
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.1370
+      IspV = 0.8640
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 378
+      heatProduction = 103
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.0885
+      IspV = 0.5580
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 4.2
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 4.2
+    }
+  }
+  
+  
+}
+@PART[engineLargeTwofold]:FOR[RealFuels_StockEngines] //Rockomax "Twofold" Liquid Engine
+{
+  @title = Rockomax "Twofold" Liquid Engine
+  @mass = 0.95
+  @cost = 179
+  %entryCost = 895
+  @maxTemp = 2359
+  @description = "Double nozzle engines are cool!" Said our engineers. And so they scrapped a bit of this and that from the debris pile and ended up with this. Although it looks cool on the outside, it tends to overheat and reveal its 'not so cool' side.
+  
+  @MODULE[ModuleEngines]
+  {
+    @maxThrust = 713
+    @heatProduction = 181
+    @atmosphereCurve
+    {
+      @key,0 = 0 214
+      @key,1 = 1 396
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 76.308310
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 23.691690
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEngines
+    techLevel = 5
+    origTechLevel = 5
+    engineType = L+
+    origMass = 0.9503
+    configuration = LqdHydrogen+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 713
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4300
+      IspV = 0.6350
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 9.5
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 950
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.1330
+      IspV = 0.5150
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 9.5
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 903
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 1.0230
+      IspV = 0.4650
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 9.5
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 950
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.1000
+      IspV = 0.5000
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 9.5
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 9.5
+    }
+  }
+  
+  
+}
+@PART[engineLargeVigor]:FOR[RealFuels_StockEngines] //Rockomax "Vigor" Liquid Engine
+{
+  @title = Rockomax "Vigor" Liquid Engine
+  @mass = 1.203
+  @cost = 206
+  %entryCost = 1030
+  @maxTemp = 2357
+  @description = A monster of an engine for heavy lifting purposes, the Mainsail's power rivals that of entire small nations.
+  
+  @MODULE[ModuleEngines]
+  {
+    @maxThrust = 900
+    @heatProduction = 181
+    @atmosphereCurve
+    {
+      @key,0 = 0 214
+      @key,1 = 1 396
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = LqdHydrogen
+      ratio = 76.308310
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 23.691690
+    }
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEngines
+    techLevel = 5
+    origTechLevel = 5
+    engineType = L+
+    origMass = 1.203
+    configuration = LqdHydrogen+LqdOxygen
+    modded = false
+    
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 900
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+      }
+      IspSL = 1.4300
+      IspV = 0.6350
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 12
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 1200
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.1330
+      IspV = 0.5150
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 12
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 1140
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+      }
+      IspSL = 1.0230
+      IspV = 0.4650
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 12
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 1200
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.1000
+      IspV = 0.5000
+      throttle = 0.65
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 12
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 12
+    }
+  }
+  
+  
+}
+@PART[engineVinci]:FOR[RealFuels_StockEngines] //Vinci Deployable Nozzle Engine
+{
+  @title = Vinci Deployable Nozzle Engine
+  @mass = 5.142
+  @cost = 4374
+  %entryCost = 21870
+  @maxTemp = 1450
+  @description = Nozzle is extendable. Isn’t that rad?
+  
+  @MODULE[ModuleEngines]
+  {
+    @maxThrust = 288
+    @heatProduction = 58
+    @atmosphereCurve
+    {
+      @key,0 = 0 242
+      @key,1 = 1 11
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = HTP
+      ratio = 100.000000
+      DrawGauge = True
+    }
+    
+  }
+  MODULE
+  {
+    name = ModuleGimbal
+    gimbalTransformName = thrustTransform
+    gimbalRange = 1
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEngines
+    techLevel = 4
+    origTechLevel = 4
+    engineType = O
+    origMass = 5.142
+    configuration = HTP
+    modded = false
+    
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 288
+      heatProduction = 58
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.0885
+      IspV = 0.6975
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 320
+      heatProduction = 58
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+      }
+      IspSL = 0.1370
+      IspV = 1.0800
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 320
+      heatProduction = 58
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+      }
+      IspSL = 0.4800
+      IspV = 1.4250
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 320
+      heatProduction = 58
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.4800
+      IspV = 1.4250
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.2
+        }
+      }
+      
+    }
+    CONFIG
+    {
+      name = UDMH+NTO
+      maxThrust = 320
+      heatProduction = 58
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 46.60730931181897
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 53.39269068818103
+      }
+      IspSL = 0.4750
+      IspV = 1.4250
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.2
+        }
+      }
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 0
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.2
+    }
+  }
+  
+  
+}


### PR DESCRIPTION
Hello,

This pull request changes quite a few things so please review it carefully in case I screwed something up.

What I did:

- Added multimode engine support for SpaceY and Atomic Age engines.
- Added a node filter (engineAccelerationSpeed) to the jet engines catch-all with the intention of solving KSPI compatibility without compromising it for other engines. My reasoning is that all jet engines have that node and should be targeted. Meanwhile, the very few rocket engines that happen to have that node should have their own config anyway and will thus be ignored. It also seems to leave Interstellar alone now.
- Added aerospike configs.
- Added various missing engine configs as well as some new ones from other mods.
- Fixed the KSO engines that I accidentally submitted on your web-app yesterday (sorry).

For your consideration.


