### PR TITLE
multifuel

### DIFF
--- a/GameData/RealFuels/StockAlike_RCS_RF.cfg
+++ b/GameData/RealFuels/StockAlike_RCS_RF.cfg
@@ -1,4 +1,6 @@
 //added B9 R6 RCS
+//added support for LazTek UltraDracos
+//added Vernor engine courtesy of Starwaster
 
 @PART[RCSBlock]:FOR[RealFuels_StockEngines] //
 {
@@ -7919,4 +7921,196 @@
     type = ServiceModule
  }
  
+}
+
+@PART[vernierEngine]:NEEDS[RealFuels]:FINAL
+{
+    @MODULE[ModuleRCS]:NEEDS[ModuleRCSFX]
+    {
+        @name = ModuleRCSFX
+    }
+    @MODULE[ModuleRCS]
+    {
+        !PROPELLANT[LiquidFuel] {}
+        !PROPELLANT[Oxidizer] {}
+        PROPELLANT
+        {
+            name = Kerosene
+            ratio = 0.38
+            %flowMode = STAGE_PRIORITY_FLOW
+        }
+        PROPELLANT
+        {
+            name = LqdOxygen
+            ratio = 0.620
+            %flowMode = STAGE_PRIORITY_FLOW
+        }
+        @atmosphereCurve
+        {
+            @key,0 = 0 304
+            @key,1 = 1 265
+        }
+    }
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleRCSFX
+        thrustRating = thrusterPower
+        techLevel = 2
+        origTechLevel = 2
+        engineType = O
+        origMass = 0.01
+        configuration = Kerosene+LqdOxygen
+        modded = false
+        CONFIG
+        {
+            name = Kerosene+LqdOxygen
+            thrusterPower = 1
+            PROPELLANT
+            {
+                name = Kerosene
+                ratio = 0.38
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.620
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 1
+            IspV = 1
+        }
+        CONFIG
+        {
+            name = LqdHydrogen+LqdOxygen
+            thrusterPower = 0.9
+            PROPELLANT
+            {
+                name = LqdHydrogen
+                ratio = 0.72856139
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = LqdOxygen
+                ratio = 0.27143861
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 1.261
+            IspV = 1.3
+        }
+        CONFIG
+        {
+            name = MMH+NTO
+            thrusterPower = 0.8
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.437
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.563
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 0.953
+            IspV = 0.952
+        }
+        CONFIG
+        {
+            name = UDMH+NTO
+            thrusterPower = 0.75
+            PROPELLANT
+            {
+                name = UDMH
+                ratio = 0.413
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.587
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 0.95
+            IspV = 0.943
+        }
+        CONFIG
+        {
+            name = Aerozine+NTO
+            thrusterPower = 0.85
+            PROPELLANT
+            {
+                name = Aerozine50
+                ratio = 0.502
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.498
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 0.963
+            IspV = 0.955
+        }
+    }
+}
+
+@PART[LazTekUltraDracoRCSNacelle]:NEEDS[RealFuels]:FINAL
+{
+    @MODULE[ModuleRCS]:NEEDS[ModuleRCSFX]
+    {
+        @name = ModuleRCSFX
+    }
+    @MODULE[ModuleRCS]
+    {
+        !PROPELLANT[LiquidFuel] {}
+        !PROPELLANT[Oxidizer] {}
+        PROPELLANT
+        {
+            name = Aerozine50
+            ratio = 0.50173
+            %flowMode = STAGE_PRIORITY_FLOW
+        }
+        PROPELLANT
+        {
+            name = NTO
+            ratio = 0.49827
+            %flowMode = STAGE_PRIORITY_FLOW
+        }
+    }
+    MODULE
+    {
+        name = ModuleEngineConfigs
+        type = ModuleRCSFX
+        thrustRating = thrusterPower
+        techLevel = 2
+        origTechLevel = 2
+        engineType = O
+        origMass = 0.01
+        configuration = MMH+NTO
+        modded = false
+        CONFIG
+        {
+            name = MMH+NTO
+            thrusterPower = 1.8
+            PROPELLANT
+            {
+                name = MMH
+                ratio = 0.51136
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            PROPELLANT
+            {
+                name = NTO
+                ratio = 0.48864
+                %flowMode = STAGE_PRIORITY_FLOW
+            }
+            IspSL = 0.95
+            IspV = 0.95
+        }
 }

--- a/GameData/RealFuels/Stockalike_BahaSP.cfg
+++ b/GameData/RealFuels/Stockalike_BahaSP.cfg
@@ -1,3 +1,5 @@
+//added Critter Crawler engine
+
 @PART[bahaRetractEngine]:FOR[RealFuels_StockEngines] //VTx-202 Retractable Engine
 {
 
@@ -482,4 +484,21 @@
   }
 
 
+}
+
+@PART[critterCrawler]:FOR[RealFuels]
+{
+    @MODULE[ModuleEngines]
+    {
+		@PROPELLANT[LiquidFuel]
+		{
+			@name = Aerozine50
+     			@ratio = 50.173
+		}
+		@PROPELLANT[Oxidizer]
+		{
+			@name = NTO
+			@ratio = 49.827
+		}
+    }
 }

--- a/GameData/RealFuels/Stockalike_LazTek.cfg
+++ b/GameData/RealFuels/Stockalike_LazTek.cfg
@@ -1,3 +1,5 @@
+//added UltraDracos
+
 @PART[LazTekSuperDracoNacelle]:FOR[RealFuels_StockEngines] //SpaceX SuperDraco Twin Engine Nacelle
 {
 
@@ -756,4 +758,272 @@
   }
 
 
+}
+
+@PART[LazTekUltraDracoNacelle]:FOR[RealFuels_StockEngines] //SpaceX UltraDraco Twin Engine Nacelle
+{
+  @title = SpaceX UltraDraco Twin Engine Nacelle
+  @mass = 0.474
+  @cost = 1262
+  %entryCost = 6310
+  @maxTemp = 2277
+  @description = Next-generation twin UltraDraco engines and nacelle radial mount to attach to SpaceX Duna Colonial Transport spacecraft. Using monopropellant for fuel, these are designed to be used as emergency escape thrusters or for powered landings.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 360
+    @heatProduction = 171
+    @atmosphereCurve
+    {
+      @key,0 = 0 325
+      @key,1 = 1 270
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = MMH
+      ratio = 51.135562
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 48.864438
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleHybridEngine
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L+
+    origMass = 0.474
+    configuration = MMH+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 360
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 4
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.6
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 360
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.0300
+      IspV = 1.0300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.6
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 4
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.6
+    }
+  }
+  
+  
+}
+
+@PART[LazTekUltraDracoRCSNacelle]:FOR[RealFuels_StockEngines] //SpaceX UltraDraco Twin Engine Nacelle with RCS
+{
+  @title = SpaceX UltraDraco Twin Engine Nacelle
+  @mass = 0.474
+  @cost = 1262
+  %entryCost = 6310
+  @maxTemp = 2277
+  @description = Next-generation combination of twin UltraDraco engines and RCS control in a nacelle radial mount to attach to SpaceX Duna Colonial Transport spacecraft. Using monopropellant for fuel, these are designed to be used as emergency escape thrusters and powered landings as well as providing reaction control.
+  
+  @MODULE[ModuleEnginesFX]
+  {
+    @maxThrust = 360
+    @heatProduction = 171
+    @atmosphereCurve
+    {
+      @key,0 = 0 325
+      @key,1 = 1 270
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = MMH
+      ratio = 51.135562
+      DrawGauge = True
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 48.864438
+    }
+  }
+  
+  MODULE
+  {
+    name = ModuleHybridEngine
+    type = ModuleEnginesFX
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L+
+    origMass = 0.474
+    configuration = MMH+NTO
+    modded = false
+    
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 360
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.135562138524485
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.864437861475515
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 4
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.6
+        }
+      }
+      
+      
+    }
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 360
+      heatProduction = 171
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.0300
+      IspV = 1.0300
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 3.6
+        }
+      }
+      
+      
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  MODULE
+  {
+    name = ModuleEngineIgnitor
+    ignitionsAvailable = 4
+    autoIgnitionTemperature = 800
+    ignitorType = Electric
+    useUllageSimulation = true
+    IGNITOR_RESOURCE
+    {
+      name = ElectricCharge
+      amount = 3.6
+    }
+  }
+  
+  
 }

--- a/GameData/RealFuels/Stockalike_SpaceY.cfg
+++ b/GameData/RealFuels/Stockalike_SpaceY.cfg
@@ -353,7 +353,7 @@
 
     CONFIG
     {
-      name = LqdMethane+LqdOxygen
+      name = LqdMethane+LqdOxygen(CenterOff)
       maxThrust = 3200
       heatProduction = 145
       PROPELLANT

--- a/GameData/RealFuels/Stockalike_SpaceY.cfg
+++ b/GameData/RealFuels/Stockalike_SpaceY.cfg
@@ -1,4 +1,5 @@
 //added multimode support for R5, M5, and M9 engines
+//now both modes have multi-mixture support!
 
 @PART[SYengine1mD1]:FOR[RealFuels_StockEngines] //SpaceY K1 “Kiwi” Engine
 {
@@ -172,7 +173,7 @@
   @cost = 10818
   %entryCost = 108180
   @maxTemp = 2394
-
+  @description = This engine from Space-Y Heavy Lifters features a dual-mode capability. The primary engine mode fires all engines at the same time, boosting thrust and heat production at a slight cost in ISP. The secondary engine mode turns the central engine off, losing some thrust and heat production for a small gain in ISP.
 
   @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
@@ -227,11 +228,12 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesFX
+    engineID = AllEngines
     techLevel = 7
     origTechLevel = 7
     engineType = L+
     origMass = 4.21
-    configuration = LqdMethane+LqdOxygen
+    configuration = LqdMethane+LqdOxygen(AllEngines)
     modded = false
 
     CONFIG
@@ -270,7 +272,7 @@
     }
     CONFIG
     {
-      name = Kerosene+LqdOxygen
+      name = Kerosene+LqdOxygen(AllEngines)
       maxThrust = 4400
       heatProduction = 181
       PROPELLANT
@@ -304,9 +306,124 @@
     }
     CONFIG
     {
-      name = LqdHydrogen+LqdOxygen
+      name = LqdHydrogen+LqdOxygen(AllEngines)
       maxThrust = 3300
       heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 74.54227709997224
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 25.45772290002776
+      }
+      IspSL = 1.3910
+      IspV = 1.3589
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 44
+        }
+      }
+
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    engineID = CenterOff
+    techLevel = 7
+    origTechLevel = 7
+    engineType = L+
+    origMass = 4.21
+    configuration = LqdMethane+LqdOxygen(CenterOff)
+    modded = false
+
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen
+      maxThrust = 3200
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.1021
+      IspV = 1.1021
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 44
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen(CenterOff)
+      maxThrust = 3200
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0700
+      IspV = 1.0700
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 44
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen(CenterOff)
+      maxThrust = 2358
+      heatProduction = 145
       PROPELLANT
       {
         name = LqdHydrogen
@@ -361,7 +478,7 @@
   @cost = 20095
   %entryCost = 200950
   @maxTemp = 2394
-
+  @description = This engine from Space-Y Heavy Lifters features a dual-mode capability. The primary engine mode fires all engines at the same time, boosting thrust and heat production at a slight cost in ISP. The secondary engine mode turns all engines except the central engine off, losing thrust and heat production for a significant gain in ISP and control precision.
 
   @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
@@ -390,11 +507,11 @@
   @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOnly]]
   {
     @maxThrust = 1200
-    @heatProduction = 24
+    @heatProduction = 92
     @atmosphereCurve
     {
-      @key,0 = 0 420
-      @key,1 = 1 345
+      @key,0 = 0 458
+      @key,1 = 1 360
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -416,16 +533,17 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesFX
+    engineID = AllEngines
     techLevel = 7
     origTechLevel = 7
     engineType = L+
     origMass = 7.846
-    configuration = LqdMethane+LqdOxygen
+    configuration = LqdMethane+LqdOxygen(AllEngines)
     modded = false
 
     CONFIG
     {
-      name = LqdMethane+LqdOxygen
+      name = LqdMethane+LqdOxygen(AllEngines)
       maxThrust = 8200
       heatProduction = 181
       PROPELLANT
@@ -459,7 +577,7 @@
     }
     CONFIG
     {
-      name = Kerosene+LqdOxygen
+      name = Kerosene+LqdOxygen(AllEngines)
       maxThrust = 8200
       heatProduction = 181
       PROPELLANT
@@ -493,7 +611,7 @@
     }
     CONFIG
     {
-      name = LqdHydrogen+LqdOxygen
+      name = LqdHydrogen+LqdOxygen(AllEngines)
       maxThrust = 6150
       heatProduction = 181
       PROPELLANT
@@ -526,6 +644,121 @@
 
     }
   }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    engineID = CenterOnly
+    techLevel = 7
+    origTechLevel = 7
+    engineType = L
+    origMass = 9.027
+    configuration = LqdMethane+LqdOxygen(CenterOnly)
+    modded = false
+
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen(CenterOnly)
+      maxThrust = 1200
+      heatProduction = 92
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.1021
+      IspV = 1.1021
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen(CenterOnly)
+      maxThrust = 1200
+      heatProduction = 92
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0700
+      IspV = 1.0700
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen(CenterOnly)
+      maxThrust = 900
+      heatProduction = 92
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 74.54227709997224
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 25.45772290002776
+      }
+      IspSL = 1.3910
+      IspV = 1.3589
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+  }
   !MODULE[ModuleEngineIgnitor] {}
   MODULE
   {
@@ -550,7 +783,7 @@
   @cost = 25330
   %entryCost = 253300
   @maxTemp = 2400
-
+  @description = This engine from Space-Y Heavy Lifters features a dual-mode capability. The primary engine mode fires all engines at the same time, boosting thrust and heat production at a slight cost in ISP. The secondary engine mode turns the central engine off, losing some thrust and heat production for a small gain in ISP.
 
   @MODULE[ModuleEnginesFX]:HAS[#engineID[AllEngines]]
   {
@@ -579,11 +812,11 @@
   @MODULE[ModuleEnginesFX]:HAS[#engineID[CenterOff]]
   {
     @maxThrust = 8800
-    @heatProduction = 190
+    @heatProduction = 152
     @atmosphereCurve
     {
-      @key,0 = 0 408
-      @key,1 = 1 369
+      @key,0 = 0 426
+      @key,1 = 1 385
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -605,16 +838,17 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesFX
+    engineID = AllEngines
     techLevel = 7
     origTechLevel = 7
     engineType = L
     origMass = 9.027
-    configuration = LqdMethane+LqdOxygen
+    configuration = LqdMethane+LqdOxygen(AllEngines)
     modded = false
 
     CONFIG
     {
-      name = LqdMethane+LqdOxygen
+      name = LqdMethane+LqdOxygen(AllEngines)
       maxThrust = 11000
       heatProduction = 190
       PROPELLANT
@@ -648,7 +882,7 @@
     }
     CONFIG
     {
-      name = Kerosene+LqdOxygen
+      name = Kerosene+LqdOxygen(AllEngines)
       maxThrust = 11000
       heatProduction = 190
       PROPELLANT
@@ -682,9 +916,124 @@
     }
     CONFIG
     {
-      name = LqdHydrogen+LqdOxygen
+      name = LqdHydrogen+LqdOxygen(AllEngines)
       maxThrust = 8250
       heatProduction = 190
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 74.54227709997224
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 25.45772290002776
+      }
+      IspSL = 1.3910
+      IspV = 1.3589
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+  }
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesFX
+    engineID = CenterOff
+    techLevel = 7
+    origTechLevel = 7
+    engineType = L
+    origMass = 9.027
+    configuration = LqdMethane+LqdOxygen(CenterOff)
+    modded = false
+
+    CONFIG
+    {
+      name = LqdMethane+LqdOxygen(CenterOff)
+      maxThrust = 8800
+      heatProduction = 152
+      PROPELLANT
+      {
+        name = LqdMethane
+        ratio = 43.54679276535492
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 56.45320723464508
+      }
+      IspSL = 1.1021
+      IspV = 1.1021
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen(CenterOff)
+      maxThrust = 8800
+      heatProduction = 152
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+      }
+      IspSL = 1.0700
+      IspV = 1.0700
+      throttle = 0
+      MODULE
+      {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        useUllageSimulation = true
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 110
+        }
+      }
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen(CenterOff)
+      maxThrust = 5896
+      heatProduction = 152
       PROPELLANT
       {
         name = LqdHydrogen


### PR DESCRIPTION
Multiple fuel mixtures for both modes courtesy of NathanKell. Wrote instructions within the description. Also changed the config names so that in the engine GUI it will show up as "fuel+fuel(mode)" instead of the regular "fuel+fuel"  so that the player can tell the difference. 

Added configs for LazTek's UltraDracos, and Bahamuto's Critter Crawler.

Added vernor engine thanks to Starwaster.

For your consideration.