### PR TITLE
Update against Module Manager 2.5.13

### DIFF
--- a/GameData/RealFuels/Jet_modularEngines.cfg
+++ b/GameData/RealFuels/Jet_modularEngines.cfg
@@ -1,9 +1,6 @@
-//engineAccelerationSpeed node allows it to target all jet engines while leaving everything else alone
-//fixed RAPIER and SCIMITAR configs
-
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[LiquidFuel]]]:Final
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[LiquidFuel]]:Final
 {
-	@MODULE[ModuleEngines*]:HAS[#engineAccelerationSpeed]
+	@MODULE[ModuleEngines*],*
 	{
 		@PROPELLANT[LiquidFuel]
 		{
@@ -13,44 +10,10 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Oxidizer]]]:Final
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[Oxidizer]]:Final
 {
-	@MODULE[ModuleEngines*]:HAS[#engineAccelerationSpeed]
+	@MODULE[ModuleEngines*],*
 	{
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			%flowMode = STACK_PRIORITY_SEARCH
-		}
-	}
-}
-
-@PART[RAPIER]:NEEDS[RealFuels,!AJE]:Final
-{
-	@MODULE[ModuleEnginesFX]:HAS[#engineID[ClosedCycle]]
-	{
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			%flowMode = STACK_PRIORITY_SEARCH
-		}
-		@PROPELLANT[Oxidizer]
-		{
-			@name = LqdOxygen
-			%flowMode = STACK_PRIORITY_SEARCH
-		}
-	}
-}
-
-@PART[mk4scimitar]:NEEDS[RealFuels]:Final
-{
-	@MODULE[ModuleEnginesFX]:HAS[#engineID[ClosedCycle]]
-	{
-		@PROPELLANT[LiquidFuel]
-		{
-			@name = Kerosene
-			%flowMode = STACK_PRIORITY_SEARCH
-		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen


### PR DESCRIPTION
Using #engineAccelerationSpeed no longer works in MM 2.5.13. So I reverted it to its original form as an all engines catch-all. It should now be able to catch secondary engine modes as well so I removed the configs for the RAPIER and SCIMITAR as they were redundant.