### PR TITLE
Update Stockalike_RLA.cfg

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_RLA.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_RLA.cfg
@@ -1,13 +1,735 @@
 //added Hydrazine to bi-modal thrusters' secondary mode
 
-@PART[RLA_mp_rad]:FOR[RealFuels_StockEngines] //RLA MPR-5R
+@PART[RLA_mp_tiny_stack]:FOR[RealFuels_StockEngines] //MPR-1 "Mist"
 {
+  @title = MPR-1 "Mist" Hypergolic Engine
+  @mass = 0.003
+  @cost = 77
+  %entryCost = 385
+  @maxTemp = 1499
 
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1
+    @heatProduction = 96
+    @atmosphereCurve
+    {
+      @key,0 = 0 159
+      @key,1 = 1 21
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = HTP
+      ratio = 100.000000
+      DrawGauge = True
+      %ResourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.003
+    configuration = HTP
+    modded = false
+
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.1770
+      IspV = 0.4650
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.2740
+      IspV = 0.7200
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.52807391613362
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.47192608386638
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  ModuleEngineIgnitor
+  {
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    useUllageSimulation = true
+
+  }
+}
+@PART[RLA_mp_tiny_radial]:FOR[RealFuels_StockEngines] //MPR-1R "Fog"
+{
+  @title = MPR-1R "Fog" Hypergolic Engine
+  @mass = 0.004
+  @cost = 77
+  %entryCost = 385
+  @maxTemp = 1499
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1
+    @heatProduction = 96
+    @atmosphereCurve
+    {
+      @key,0 = 0 159
+      @key,1 = 1 21
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = HTP
+      ratio = 100.000000
+      DrawGauge = True
+      %ResourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.0035
+    configuration = HTP
+    modded = false
+
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.1770
+      IspV = 0.4650
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.2740
+      IspV = 0.7200
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.52807391613362
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.47192608386638
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  ModuleEngineIgnitor
+  {
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    useUllageSimulation = true
+
+  }
+
+
+}
+@PART[RLA_mp_tiny_vac]:FOR[RealFuels_StockEngines] //LV-0 "Aphid" Engine - Same stats as the "Mist"
+{
+  @title = LV-0 "Aphid" Engine
+  @mass = 0.003
+  @cost = 77
+  %entryCost = 385
+  @maxTemp = 1499
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1
+    @heatProduction = 96
+    @atmosphereCurve
+    {
+      @key,0 = 0 159
+      @key,1 = 1 21
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = HTP
+      ratio = 100.000000
+      DrawGauge = True
+      %ResourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.003
+    configuration = HTP
+    modded = false
+
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.1770
+      IspV = 0.4650
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.2740
+      IspV = 0.7200
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.52807391613362
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.47192608386638
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 1
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.01
+        }
+      }
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  ModuleEngineIgnitor
+  {
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    useUllageSimulation = true
+
+  }
+
+
+}
+@PART[RLA_mp_small_stack]:FOR[RealFuels_StockEngines] //RLA MPR-5 "Cirrus"
+{
+  @title = MPR-5 "Cirrus" Hypergolic Engine
+  @mass = 0.015
+  @cost = 86
+  %entryCost = 430
+  @maxTemp = 1499
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 5
+    @heatProduction = 96
+    @atmosphereCurve
+    {
+      @key,0 = 0 159
+      @key,1 = 1 21
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = HTP
+      ratio = 100.000000
+      DrawGauge = True
+      %ResourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = O
+    origMass = 0.015
+    configuration = HTP
+    modded = false
+
+    CONFIG
+    {
+      name = HTP
+      maxThrust = 5
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = HTP
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.1770
+      IspV = 0.4650
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.05
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Hydrazine
+      maxThrust = 5
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Hydrazine
+        ratio = 100
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.2740
+      IspV = 0.7200
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.05
+        }
+      }
+
+
+    }
+    CONFIG
+    {
+      name = MMH+NTO
+      maxThrust = 5
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = MMH
+        ratio = 51.52807391613362
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 48.47192608386638
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.05
+        }
+      }
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 5
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 0.05
+        }
+      }
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  ModuleEngineIgnitor
+  {
+    ignitionsAvailable = 24
+    autoIgnitionTemperature = 800
+    useUllageSimulation = true
+
+  }
+}
+@PART[RLA_mp_small_radial]:FOR[RealFuels_StockEngines] //MPR-5R "Stratus"
+{
+  @title = MPR-5R "Stratus" Hypergolic Engine
   @mass = 0.017
   @cost = 86
   %entryCost = 430
   @maxTemp = 1450
-
 
   @MODULE[ModuleEngine*]
   {
@@ -136,593 +858,23 @@
           amount = 0.05
         }
       }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_mp_tiny]:FOR[RealFuels_StockEngines] //RLA MPR-1
-{
-
-  @mass = 0.003
-  @cost = 77
-  %entryCost = 385
-  @maxTemp = 1499
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 1
-    @heatProduction = 96
-    @atmosphereCurve
-    {
-      @key,0 = 0 159
-      @key,1 = 1 21
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = HTP
-      ratio = 100.000000
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
-    engineType = O
-    origMass = 0.003
-    configuration = HTP
-    modded = false
-
-    CONFIG
-    {
-      name = HTP
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
     }
     CONFIG
     {
-      name = Hydrazine
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = NTO
-        ratio = 48.47192608386638
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.9600
-      IspV = 0.9500
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_mp_tr]:FOR[RealFuels_StockEngines] //MPR-1R Monopropellant Engine
-{
-
-  @mass = 0.004
-  @cost = 77
-  %entryCost = 385
-  @maxTemp = 1499
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 1
-    @heatProduction = 96
-    @atmosphereCurve
-    {
-      @key,0 = 0 159
-      @key,1 = 1 21
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = HTP
-      ratio = 100.000000
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
-    engineType = O
-    origMass = 0.0035
-    configuration = HTP
-    modded = false
-
-    CONFIG
-    {
-      name = HTP
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = Hydrazine
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = NTO
-        ratio = 48.47192608386638
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.9600
-      IspV = 0.9500
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_mp_t]:FOR[RealFuels_StockEngines] //MPR-1 Monopropellant Engine
-{
-
-  @mass = 0.003
-  @cost = 77
-  %entryCost = 385
-  @maxTemp = 1499
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 1
-    @heatProduction = 96
-    @atmosphereCurve
-    {
-      @key,0 = 0 159
-      @key,1 = 1 21
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = HTP
-      ratio = 100.000000
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
-    engineType = O
-    origMass = 0.003
-    configuration = HTP
-    modded = false
-
-    CONFIG
-    {
-      name = HTP
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = Hydrazine
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 1
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = NTO
-        ratio = 48.47192608386638
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.9600
-      IspV = 0.9500
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.01
-        }
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_mp_small]:FOR[RealFuels_StockEngines] //RLA MPR-5
-{
-
-  @mass = 0.015
-  @cost = 86
-  %entryCost = 430
-  @maxTemp = 1499
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 5
-    @heatProduction = 96
-    @atmosphereCurve
-    {
-      @key,0 = 0 159
-      @key,1 = 1 21
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = HTP
-      ratio = 100.000000
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
-    engineType = O
-    origMass = 0.015
-    configuration = HTP
-    modded = false
-
-    CONFIG
-    {
-      name = HTP
+      name = Aerozine50+NTO
       maxThrust = 5
       heatProduction = 96
       PROPELLANT
       {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.05
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = Hydrazine
-      maxThrust = 5
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.05
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 5
-      heatProduction = 96
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
+        name = Aerozine50
+        ratio = 50.17301038062284
         DrawGauge = True
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 48.47192608386638
+        ratio = 49.82698961937716
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600
@@ -740,8 +892,6 @@
           amount = 0.05
         }
       }
-
-
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
@@ -755,19 +905,17 @@
 
 
 }
-@PART[RLA_s_highengine]:FOR[RealFuels_StockEngines] //RLA Spinnaker
-{
-
-  @mass = 0.044
+@PART[RLA_small_highthrust]:FOR[RealFuels_StockEngines] //88-M6 "Spinnaker"
+{  
+  @mass = 0.08
   @cost = 158
   %entryCost = 790
   @maxTemp = 2157
 
-
   @MODULE[ModuleEngine*]
   {
     @name = ModuleEnginesRF
-    @maxThrust = 30
+    @maxThrust = 90
     @heatProduction = 165
     @atmosphereCurve
     {
@@ -799,14 +947,14 @@
     techLevel = 4
     origTechLevel = 4
     engineType = L+
-    origMass = 0.044
+    origMass = 0.08
     configuration = Kerosene+HTP
     modded = false
 
     CONFIG
     {
       name = Kerosene+HTP
-      maxThrust = 30
+      maxThrust = 70
       heatProduction = 165
       PROPELLANT
       {
@@ -836,13 +984,11 @@
           amount = 0.3
         }
       }
-
-
     }
     CONFIG
     {
       name = Kerosene+LqdOxygen
-      maxThrust = 30
+      maxThrust = 90
       heatProduction = 165
       PROPELLANT
       {
@@ -872,13 +1018,11 @@
           amount = 0.3
         }
       }
-
-
     }
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 23
+      maxThrust = 45
       heatProduction = 165
       PROPELLANT
       {
@@ -908,8 +1052,6 @@
           amount = 0.3
         }
       }
-
-
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
@@ -918,185 +1060,24 @@
     ignitionsAvailable = 1
     autoIgnitionTemperature = 800
     useUllageSimulation = true
-
   }
-
-
 }
-@PART[RLA_s_lowengine]:FOR[RealFuels_StockEngines] //RLA LV-T5
+@PART[RLA_small_spike]:FOR[RealFuels_StockEngines] //36-5D "Caravel" Annular Aerospike Engine
 {
-
   @mass = 0.015
   @cost = 86
   %entryCost = 430
   @maxTemp = 1523
 
-
   @MODULE[ModuleEngine*]
   {
     @name = ModuleEnginesRF
     @maxThrust = 5
-    @heatProduction = 95
+    @heatProduction = 200
     @atmosphereCurve
     {
-      @key,0 = 0 330
-      @key,1 = 1 116
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = MMH
-      ratio = 51.528074
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-    PROPELLANT
-    {
-      name = NTO
-      ratio = 48.471926
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 4
-    origTechLevel = 4
-    engineType = O
-    origMass = 0.015
-    configuration = MMH+NTO
-    modded = false
-
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 5
-      heatProduction = 95
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = NTO
-        ratio = 48.47192608386638
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.9600
-      IspV = 0.9500
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.05
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = HTP
-      maxThrust = 5
-      heatProduction = 95
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.05
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = Hydrazine
-      maxThrust = 5
-      heatProduction = 95
-      PROPELLANT
-      {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.05
-        }
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_s_midengine]:FOR[RealFuels_StockEngines] //RLA Kingfisher
-{
-
-  @mass = 0.025
-  @cost = 113
-  %entryCost = 565
-  @maxTemp = 1906
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 15
-    @heatProduction = 134
-    @atmosphereCurve
-    {
-      @key,0 = 0 313
-      @key,1 = 1 188
+      @key,0 = 0 350
+      @key,1 = 1 315
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -1104,14 +1085,14 @@
     PROPELLANT
     {
       name = Kerosene
-      ratio = 17.722313
+      ratio = 37.694087
       DrawGauge = True
       %ResourceFlowMode = STACK_PRIORITY_SEARCH
     }
     PROPELLANT
     {
-      name = HTP
-      ratio = 82.277687
+      name = LqdOxygen
+      ratio = 62.305913
       %ResourceFlowMode = STACK_PRIORITY_SEARCH
     }
   }
@@ -1122,63 +1103,27 @@
     type = ModuleEnginesRF
     techLevel = 4
     origTechLevel = 4
-    engineType = U
-    origMass = 0.025
-    configuration = Kerosene+HTP
+    engineType = A
+    origMass = 0.015
+    configuration = Kerosene+LqdOxygen
     modded = false
 
     CONFIG
     {
-      name = Kerosene+HTP
-      maxThrust = 15
-      heatProduction = 134
-      PROPELLANT
-      {
-        name = Kerosene
-        ratio = 17.7223128057193
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 82.2776871942807
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.9200
-      IspV = 0.9200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 1
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.15
-        }
-      }
-
-
-    }
-    CONFIG
-    {
       name = Kerosene+LqdOxygen
-      maxThrust = 15
-      heatProduction = 134
+      maxThrust = 5
+      heatProduction = 200
       PROPELLANT
       {
         name = Kerosene
-        ratio = 35.75681604512692
+        ratio = 37.69408655434424
         DrawGauge = True
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 64.24318395487307
+        ratio = 62.30591344565576
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 1.0000
@@ -1186,14 +1131,14 @@
       throttle = 0
       ModuleEngineIgnitor
       {
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         useUllageSimulation = true
         autoIgnitionTemperature = 800
         ignitorType = Electric
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 0.15
+          amount = 2.1
         }
       }
 
@@ -1202,19 +1147,19 @@
     CONFIG
     {
       name = LqdHydrogen+LqdOxygen
-      maxThrust = 11
-      heatProduction = 134
+      maxThrust = 5
+      heatProduction = 200
       PROPELLANT
       {
         name = LqdHydrogen
-        ratio = 74.54227709997224
+        ratio = 76.30830964721619
         DrawGauge = True
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = LqdOxygen
-        ratio = 25.45772290002776
+        ratio = 23.69169035278381
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 1.3000
@@ -1222,40 +1167,34 @@
       throttle = 0
       ModuleEngineIgnitor
       {
-        ignitionsAvailable = 1
+        ignitionsAvailable = 4
         useUllageSimulation = true
         autoIgnitionTemperature = 800
         ignitorType = Electric
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 0.15
+          amount = 2.1
         }
       }
-
-
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
   ModuleEngineIgnitor
   {
-    ignitionsAvailable = 1
+    ignitionsAvailable = 4
     autoIgnitionTemperature = 800
     useUllageSimulation = true
 
   }
-
-
 }
-@PART[RLA_s_nerva]:FOR[RealFuels_StockEngines] //RLA NERVA
+@PART[RLA_small_ntr]:FOR[RealFuels_StockEngines] //LV-Nc "Mighty" Atomic Rocket Motor
 {
-
   @mass = 0.4
   @cost = 1624
   %entryCost = 8120
   @maxTemp = 2400
-
-
+  
   @MODULE[ModuleEngine*]
   {
     @name = ModuleEnginesRF
@@ -1276,9 +1215,7 @@
       DrawGauge = True
       %ResourceFlowMode = STACK_PRIORITY_SEARCH
     }
-
   }
-
   MODULE
   {
     name = ModuleEngineConfigs
@@ -1462,14 +1399,12 @@
   }
 
 }
-@PART[RLA_linearspike_med]:FOR[RealFuels_StockEngines] //RLA Cutter
+@PART[RLA_lfo_medium_linearspike]:FOR[RealFuels_StockEngines] //RE-D2 "Cutter" Linear Aerospike Engine
 {
-
   @mass = 0.39
   @cost = 921
   %entryCost = 4605
   @maxTemp = 2400
-
 
   @MODULE[ModuleEngine*]
   {
@@ -1594,14 +1529,13 @@
 
 
 }
-@PART[RLA_mp_l_spike]:FOR[RealFuels_StockEngines] //TtKH-6B “Cormorant” Monopropellant Engine
+@PART[RLA_mp_large_spike]:FOR[RealFuels_StockEngines] //TtKH-6B "Cormorant" Monopropellant Engine
 {
-
+  @title = TtKH-6B "Cormorant" Hypergolic Engine
   @mass = 0.823
   @cost = 764
   %entryCost = 3820
   @maxTemp = 1534
-
 
   @MODULE[ModuleEngine*]
   {
@@ -1632,7 +1566,7 @@
     type = ModuleEnginesRF
     techLevel = 5
     origTechLevel = 5
-    engineType = O
+    engineType = A
     origMass = 0.823
     configuration = Hydrazine
     modded = false
@@ -1664,8 +1598,6 @@
           amount = 2.85
         }
       }
-
-
     }
     CONFIG
     {
@@ -1730,8 +1662,40 @@
           amount = 2.85
         }
       }
-
-
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 285
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.85
+        }
+      }
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
@@ -1740,19 +1704,15 @@
     ignitionsAvailable = 24
     autoIgnitionTemperature = 800
     useUllageSimulation = true
-
   }
-
-
 }
-@PART[RLA_mp_l_vac]:FOR[RealFuels_StockEngines] //TtK-6A “Albatross” Monopropellant Engine
+@PART[RLA_mp_large_vac]:FOR[RealFuels_StockEngines] //TtK-6A “Albatross” Monopropellant Engine
 {
-
+  @title = TtK-6A “Albatross” Hypergolic Engine
   @mass = 0.534
   @cost = 522
   %entryCost = 2610
   @maxTemp = 1534
-
 
   @MODULE[ModuleEngine*]
   {
@@ -1774,7 +1734,6 @@
       DrawGauge = True
       %ResourceFlowMode = STACK_PRIORITY_SEARCH
     }
-
   }
 
   MODULE
@@ -1815,8 +1774,6 @@
           amount = 1.85
         }
       }
-
-
     }
     CONFIG
     {
@@ -1845,8 +1802,6 @@
           amount = 1.85
         }
       }
-
-
     }
     CONFIG
     {
@@ -1881,8 +1836,40 @@
           amount = 1.85
         }
       }
-
-
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 185
+      heatProduction = 96
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %ResourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 24
+        useUllageSimulation = true
+        autoIgnitionTemperature = 800
+        ignitorType = Electric
+        IGNITOR_RESOURCE
+        {
+          name = ElectricCharge
+          amount = 2.85
+        }
+      }
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
@@ -1896,14 +1883,13 @@
 
 
 }
-@PART[RLA_mp_m_vac]:FOR[RealFuels_StockEngines] //MPR-45 Monopropellant Engine
+@PART[RLA_mp_medium_vac]:FOR[RealFuels_StockEngines] //MPR-50 "Nimbus" Monopropellant Engine
 {
-
+  @title = MPR-50 "Nimbus" Monopropellant Engine
   @mass = 0.14
   @cost = 177
   %entryCost = 885
   @maxTemp = 1506
-
 
   @MODULE[ModuleEngine*]
   {
@@ -1966,8 +1952,6 @@
           amount = 0.45
         }
       }
-
-
     }
     CONFIG
     {
@@ -1996,8 +1980,6 @@
           amount = 0.45
         }
       }
-
-
     }
     CONFIG
     {
@@ -2032,140 +2014,23 @@
           amount = 0.45
         }
       }
-
-
     }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
-
-}
-@PART[RLA_mp_med]:FOR[RealFuels_StockEngines] //RLA MPR-45
-{
-
-  @mass = 0.14
-  @cost = 177
-  %entryCost = 885
-  @maxTemp = 1506
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 45
-    @heatProduction = 93
-    @atmosphereCurve
-    {
-      @key,0 = 0 250
-      @key,1 = 1 33
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = Hydrazine
-      ratio = 100.000000
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 4
-    origTechLevel = 4
-    engineType = O
-    origMass = 0.14
-    configuration = Hydrazine
-    modded = false
-
     CONFIG
     {
-      name = Hydrazine
+      name = Aerozine50+NTO
       maxThrust = 45
-      heatProduction = 93
+      heatProduction = 96
       PROPELLANT
       {
-        name = Hydrazine
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.2740
-      IspV = 0.7200
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.45
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = HTP
-      maxThrust = 41
-      heatProduction = 93
-      PROPELLANT
-      {
-        name = HTP
-        ratio = 100
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 0.1770
-      IspV = 0.4650
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.45
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = MMH+NTO
-      maxThrust = 45
-      heatProduction = 93
-      PROPELLANT
-      {
-        name = MMH
-        ratio = 51.52807391613362
+        name = Aerozine50
+        ratio = 50.17301038062284
         DrawGauge = True
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       PROPELLANT
       {
         name = NTO
-        ratio = 48.47192608386638
+        ratio = 49.82698961937716
         %ResourceFlowMode = STACK_PRIORITY_SEARCH
       }
       IspSL = 0.9600
@@ -2180,11 +2045,9 @@
         IGNITOR_RESOURCE
         {
           name = ElectricCharge
-          amount = 0.45
+          amount = 0.05
         }
       }
-
-
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
@@ -2198,108 +2061,7 @@
 
 
 }
-@PART[RLA_solid_s_long]:FOR[RealFuels_StockEngines] //Boostertron II Solid Rocket Booster
-{
-
-  @mass = 0.3
-  @cost = 117
-  %entryCost = 585
-  @maxTemp = 1800
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 55
-    @heatProduction = 176
-    @atmosphereCurve
-    {
-      @key,0 = 0 247
-      @key,1 = 1 172
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = SolidFuel
-      ratio = 100.000000
-      DrawGauge = True
-
-    }
-
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 1
-    origTechLevel = 1
-    engineType = S+
-    origMass = 0.3
-    configuration = SolidFuel
-    modded = false
-
-    CONFIG
-    {
-      name = SolidFuel
-      maxThrust = 55
-      heatProduction = 176
-      PROPELLANT
-      {
-        name = SolidFuel
-        ratio = 100
-        DrawGauge = True
-
-      }
-      IspSL = 1.0000
-      IspV = 1.0000
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 1
-        useUllageSimulation = false
-        autoIgnitionTemperature = 800
-
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 1
-    autoIgnitionTemperature = 800
-    useUllageSimulation = false
-
-  }
-
-  !RESOURCE[LiquidFuel] {}
-  !RESOURCE[Oxidizer] {}
-  !RESOURCE[MonoPropellant] {}
-  !RESOURCE[SolidFuel] {}
-  !RESOURCE[XenonGas] {}
-  MODULE
-  {
-    name = ModuleFuelTanks
-    basemass = -1
-    volume = 800
-    type = Solid
-    // dedicated = false
-    TANK
-    {
-     name = SolidFuel
-     amount = full
-     maxAmount = 100.000000%
-    }
-
-  }
-
-
-}
-@PART[RLA_solid_s_short]:FOR[RealFuels_StockEngines] //Boostertron I Solid Rocket Booster
+@PART[RLA_solid_small_short]:FOR[RealFuels_StockEngines] //Boostertron I Solid Rocket Booster
 {
 
   @mass = 0.12
@@ -2400,24 +2162,24 @@
 
 
 }
-@PART[RLA_solid_s_upper]:FOR[RealFuels_StockEngines] //GmG-2A “Puffin” Payload Assist Motor
+@PART[RLA_solid_small_medium]:FOR[RealFuels_StockEngines] //Boostertron II Solid Rocket Booster
 {
 
-  @mass = 0.07
-  @cost = 94
-  %entryCost = 470
+  @mass = 0.3
+  @cost = 117
+  %entryCost = 585
   @maxTemp = 1800
 
 
   @MODULE[ModuleEngine*]
   {
     @name = ModuleEnginesRF
-    @maxThrust = 20
-    @heatProduction = 189
+    @maxThrust = 55
+    @heatProduction = 176
     @atmosphereCurve
     {
-      @key,0 = 0 273
-      @key,1 = 1 192
+      @key,0 = 0 247
+      @key,1 = 1 172
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -2436,18 +2198,18 @@
   {
     name = ModuleEngineConfigs
     type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
+    techLevel = 1
+    origTechLevel = 1
     engineType = S+
-    origMass = 0.07
+    origMass = 0.3
     configuration = SolidFuel
     modded = false
 
     CONFIG
     {
       name = SolidFuel
-      maxThrust = 20
-      heatProduction = 189
+      maxThrust = 55
+      heatProduction = 176
       PROPELLANT
       {
         name = SolidFuel
@@ -2487,7 +2249,7 @@
   {
     name = ModuleFuelTanks
     basemass = -1
-    volume = 200
+    volume = 480
     type = Solid
     // dedicated = false
     TANK
@@ -2501,7 +2263,108 @@
 
 
 }
-@PART[RLA_solid_m_upper]:FOR[RealFuels_StockEngines] //Rockomax SMAC Payload Assist Motor
+@PART[RLA_solid_small_long]:FOR[RealFuels_StockEngines] //Boostertron III Solid Rocket Booster
+{
+
+  @mass = 0.6
+  @cost = 117
+  %entryCost = 585
+  @maxTemp = 1800
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 55
+    @heatProduction = 176
+    @atmosphereCurve
+    {
+      @key,0 = 0 247
+      @key,1 = 1 172
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = SolidFuel
+      ratio = 100.000000
+      DrawGauge = True
+
+    }
+
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 1
+    origTechLevel = 1
+    engineType = S+
+    origMass = 0.3
+    configuration = SolidFuel
+    modded = false
+
+    CONFIG
+    {
+      name = SolidFuel
+      maxThrust = 55
+      heatProduction = 176
+      PROPELLANT
+      {
+        name = SolidFuel
+        ratio = 100
+        DrawGauge = True
+
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ModuleEngineIgnitor
+      {
+        ignitionsAvailable = 1
+        useUllageSimulation = false
+        autoIgnitionTemperature = 800
+
+      }
+
+
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+  ModuleEngineIgnitor
+  {
+    ignitionsAvailable = 1
+    autoIgnitionTemperature = 800
+    useUllageSimulation = false
+
+  }
+
+  !RESOURCE[LiquidFuel] {}
+  !RESOURCE[Oxidizer] {}
+  !RESOURCE[MonoPropellant] {}
+  !RESOURCE[SolidFuel] {}
+  !RESOURCE[XenonGas] {}
+  MODULE
+  {
+    name = ModuleFuelTanks
+    basemass = -1
+    volume = 960
+    type = Solid
+    // dedicated = false
+    TANK
+    {
+     name = SolidFuel
+     amount = full
+     maxAmount = 100.000000%
+    }
+
+  }
+
+
+}
+@PART[RLA_solid_medium_upper]:FOR[RealFuels_StockEngines] //Rockomax SMAC Payload Assist Motor
 {
 
   @mass = 0.11
@@ -2603,7 +2466,7 @@
 
 }
 
-@PART[RLA_resistojet]:FOR[RealFuels] //Bi-Modal Resistojet Thruster
+@PART[RLA_small_resistojet]:FOR[RealFuels] //Bi-Modal Resistojet Thruster
 {
     @MODULE[ModuleEnginesFX]:HAS[#engineID[Monopropellant]]
     {
@@ -2614,7 +2477,7 @@
     }
 }
 
-@PART[RLA_arcjet]:FOR[RealFuels] //Bi-Modal Arcjet Thruster
+@PART[RLA_small_arcjet]:FOR[RealFuels] //Bi-Modal Arcjet Thruster
 {
     @MODULE[ModuleEnginesFX]:HAS[#engineID[Monopropellant]]
     {
@@ -2623,178 +2486,4 @@
 			@name = Hydrazine
 		}
     }
-}
-
-@PART[RLA_lfo_m_linearspike]:FOR[RealFuels_StockEngines] //Rockomax "Cutter" Linear Aerospike Engine
-{
-
-  @mass = 1.504
-  @cost = 1335
-  %entryCost = 6675
-  @maxTemp = 2400
-
-
-  @MODULE[ModuleEngine*]
-  {
-    @name = ModuleEnginesRF
-    @maxThrust = 210
-    @heatProduction = 253
-    @atmosphereCurve
-    {
-      @key,0 = 0 369
-      @key,1 = 1 362
-    }
-    !PROPELLANT[LiquidFuel] {}
-    !PROPELLANT[Oxidizer] {}
-    !PROPELLANT[MonoPropellant] {}
-    PROPELLANT
-    {
-      name = Kerosene
-      ratio = 37.694087
-      DrawGauge = True
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-    PROPELLANT
-    {
-      name = LqdOxygen
-      ratio = 62.305913
-      %ResourceFlowMode = STACK_PRIORITY_SEARCH
-    }
-  }
-
-  MODULE
-  {
-    name = ModuleEngineConfigs
-    type = ModuleEnginesRF
-    techLevel = 3
-    origTechLevel = 3
-    engineType = A
-    origMass = 1.504
-    configuration = Kerosene+LqdOxygen
-    modded = false
-
-    CONFIG
-    {
-      name = Kerosene+LqdOxygen
-      maxThrust = 210
-      heatProduction = 253
-      PROPELLANT
-      {
-        name = Kerosene
-        ratio = 37.69408655434424
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 62.30591344565576
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 1.2000
-      IspV = 1.1000
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = -1
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2.1
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = LqdMethane+LqdOxygen
-      maxThrust = 202
-      heatProduction = 253
-      PROPELLANT
-      {
-        name = LqdMethane
-        ratio = 49.35852518630139
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 50.64147481369861
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 1.2360
-      IspV = 1.1330
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 0
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2.1
-        }
-      }
-
-
-    }
-    CONFIG
-    {
-      name = LqdHydrogen+LqdOxygen
-      maxThrust = 158
-      heatProduction = 253
-      PROPELLANT
-      {
-        name = LqdHydrogen
-        ratio = 76.30830964721619
-        DrawGauge = True
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      PROPELLANT
-      {
-        name = LqdOxygen
-        ratio = 23.69169035278381
-        %ResourceFlowMode = STACK_PRIORITY_SEARCH
-      }
-      IspSL = 1.5600
-      IspV = 1.3970
-      throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 0
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        useUllageSimulation = true
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 2.1
-        }
-      }
-
-
-    }
-  }
-  !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 0
-    autoIgnitionTemperature = 800
-    ignitorType = Electric
-    useUllageSimulation = true
-    IGNITOR_RESOURCE
-    {
-      name = ElectricCharge
-      amount = 2.1
-    }
-  }
-
-
 }


### PR DESCRIPTION
RLA Stockalike v13 changed part names. I corrected them in this pull request. Also added Aerozine50+NTO configs for the "monopropellant" engines.

The 88-M6 "Spinnaker" is supposed to be (in the RLA Stockalike mod) the low efficiency high thrust engine in the small rockomax family. As it was configured it seemed to be worse than the 48-7S (liquidEngineMini) in every way. Made it an "L" engine with a kerolox thrust of 90, putting it at the top end of the small engines, power wise.