### PR TITLE
Fix engines showing up in "FuelTank" category.

### DIFF
--- a/GameData/RealFuels-Stockalike/fix-part-categories.cfg
+++ b/GameData/RealFuels-Stockalike/fix-part-categories.cfg
@@ -1,0 +1,8 @@
+// The game auto-sorts parts with category "Propulsion" into "Engine" if they
+//  have one of the stock engine modules; otherwise "FuelTank".
+// Because the auto-sort doesn't recognize ModuleEnginesRF as an engine module,
+//  we need ModuleManager to do the sort for us.
+
+@PART[*]:HAS[#category[Propulsion],@MODULE[ModuleEnginesRF]]:FINAL {
+    @category = Engine
+}


### PR DESCRIPTION
There are a lot of engines in the wild (including Squad's Mammoth and Rhino) that still have their part category set to the old "Propulsion" instead of "Engine". The game auto-sorts them into the "Engines" tab as long as they have one of the stock engine modules, but engines that use ModuleEnginesRF end up in "Fuel Tanks".

If we can ship this ModuleManager patch to put all of the affected engines back in the right category, it will improve the out-of-the-box experience.