### PR TITLE
Fix RealPlume effects for Cryogenic Engines in methalox mode.

### DIFF
--- a/GameData/RealPlume/RealPlume-RFStockalike/Corvus&Cryo.cfg
+++ b/GameData/RealPlume/RealPlume-RFStockalike/Corvus&Cryo.cfg
@@ -134,7 +134,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen,LqdMethane+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Upper
         }

--- a/GameData/RealPlume/RealPlume-RFStockalike/Corvus&Cryo.cfg
+++ b/GameData/RealPlume/RealPlume-RFStockalike/Corvus&Cryo.cfg
@@ -84,7 +84,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Lower
         }
@@ -184,7 +184,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen,LqdMethane+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Lower
         }
@@ -234,7 +234,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen,LqdMethane+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Upper
         }
@@ -284,7 +284,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen,LqdMethane+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Lower
         }
@@ -334,7 +334,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-		@CONFIG[Kerosene+LqdOxygen,LqdMethane+LqdOxygen]  //Add the effect to every engine config
+		@CONFIG[LqdMethane+LqdOxygen]  //Add the effect to every engine config
         {
             %powerEffectName = Kerolox-Upper
         }


### PR DESCRIPTION
I noticed that none of the engines in Nertea's Cryogenic Engines pack had RealPlume effects in methalox mode. Some had plumes configured for a nonexistent kerolox mode, and some were using ModuleManager syntax that no longer works.

I've fixed the RealPlume configuration to provide effects for these engines in all of their available modes.