### PR TITLE
Multimode engines

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_MarkIVSystem.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_MarkIVSystem.cfg
@@ -1,33 +1,33 @@
-@PART[B9_Engine_SABRE_*]:FOR[RealFuels_StockEngines]
-{
+@PART[mk4multimodal-*]:FOR[RealFuels_StockEngines]
+{	
 	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
+			@name = LqdMethane
 			@ratio = 1
 			@DrawGauge = True
 		}
 	}
-	@MODULE[ModuleEnginesFX*]:HAS[#engineID[ClosedCycle]]
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
-			@ratio = 0.73
+			@name = LqdMethane
+			@ratio = 0.45
 			@DrawGauge = True
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.27
+			@ratio = 0.55
 			%DrawGauge = True
 		}
 		!atmosphereCurve {}
 		atmosphereCurve
 		{
-			key = 0 460
-			key = 1 408
+			key = 0 366
+			key = 1 330
 		}
 	}
 }

--- a/GameData/RealFuels-Stockalike/Stockalike_Squad_Rapier.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_Squad_Rapier.cfg
@@ -1,33 +1,33 @@
-@PART[B9_Engine_SABRE_*]:FOR[RealFuels_StockEngines]
-{
+@PART[RAPIER]:FOR[RealFuels_StockEngines]
+{	
 	@MODULE[ModuleEngines*]:HAS[#engineID[AirBreathing]]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
+			@name = LqdMethane
 			@ratio = 1
 			@DrawGauge = True
 		}
 	}
-	@MODULE[ModuleEnginesFX*]:HAS[#engineID[ClosedCycle]]
+	@MODULE[ModuleEngines*]:HAS[#engineID[ClosedCycle]]
 	{
 		@PROPELLANT[LiquidFuel]
 		{
-			@name = LqdHydrogen
-			@ratio = 0.73
+			@name = LqdMethane
+			@ratio = 0.45
 			@DrawGauge = True
 		}
 		@PROPELLANT[Oxidizer]
 		{
 			@name = LqdOxygen
-			@ratio = 0.27
+			@ratio = 0.55
 			%DrawGauge = True
 		}
 		!atmosphereCurve {}
 		atmosphereCurve
 		{
-			key = 0 460
-			key = 1 408
+			key = 0 366
+			key = 1 330
 		}
 	}
 }


### PR DESCRIPTION
* B9 SABRE:
* Allow fuel patches to apply to SABRE even without AJE
* Remove heatProduction patch which is very old and not up-to-date on
1.0+ heating changes
* Get rid of patch removing IntakeAir (AJE will do this itself when it
needs to)
* Add atmosphere curve of tweaked aerospike (max TL from config
generator) for closed cycle (tweaked vacuum Isp up 2% to 460s to match
data and SL Isp down 2%)
* Add fuel patch to RAPIER so that it runs on Methane
* Give rocket mode atmosphereCurve of aerospike at max TL
* Add MarkIVSystem multi mode engines same as RAPIER