### PR TITLE
Part name updates and RealPlume settings for HGR

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_HGR.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_HGR.cfg
@@ -155,7 +155,7 @@
 
 
 }
-@PART[G90]:FOR[RealFuels_StockEngines] //HGR G90 Engine
+@PART[HGR_FG90_Engine]:FOR[RealFuels_StockEngines] //HGR G90 Engine
 {
 
   @mass = 0.7
@@ -465,7 +465,7 @@
 
 
 }
-@PART[G120]:FOR[RealFuels_StockEngines] //HGR G-120 Engine
+@PART[FG120]:FOR[RealFuels_StockEngines] //HGR G-120 Engine
 {
 
   @mass = 0.9

--- a/GameData/RealPlume-RFStockalike/HGR.cfg
+++ b/GameData/RealPlume-RFStockalike/HGR.cfg
@@ -1,0 +1,126 @@
+// RealPlume settings for HGR with RFStockalike.
+// Tested on HGR 1.3.0 with HGR Community Fixes 1.4 "Ogres are like Garlics"
+
+@PART[SoySvcMod]:BEFORE[RealPlume] {
+    PLUME {
+        name = Hypergolic-OMS-White
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+
+    @MODULE[ModuleEngineConfigs] {
+        @CONFIG,* {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+
+@PART[HGRG47b]:BEFORE[RealPlume] {
+    PLUME {
+        name = Hypergolic-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.7
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+
+    PLUME {
+        name = Kerolox-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0.7
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+
+    PLUME {
+        name = Hydrolox-Upper
+        transformName = thrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,1.2
+        fixedScale = 0.75
+        energy = 1
+        speed = 1
+    }
+
+    @MODULE[ModuleEngineConfigs] {
+        @CONFIG[UDMH+NTO] {
+            %powerEffectName = Hypergolic-Upper
+        }
+        @CONFIG[Kerosene+LqdOxygen] {
+            %powerEffectName = Kerolox-Upper
+        }
+        @CONFIG[LqdHydrogen+LqdOxygen] {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+
+@PART[HGR_FG90_Engine]:BEFORE[RealPlume] {
+    PLUME {
+        name = Hypergolic-Lower
+        transformName = ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+
+    PLUME {
+        name = Kerolox-Lower
+        transformName = ThrustTransform
+        localRotation = 0,0,0
+        localPosition = 0,0,0
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+
+    @MODULE[ModuleEngineConfigs] {
+        @CONFIG[UDMH+NTO] {
+            %powerEffectName = Hypergolic-Lower
+        }
+        @CONFIG[Kerosene+LqdOxygen] {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+
+@PART[FG120]:BEFORE[RealPlume] {
+    PLUME {
+        name = Hypergolic-Lower
+        transformName = MainThrustFX
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+
+    PLUME {
+        name = Kerolox-Lower
+        transformName = MainThrustFX
+        localRotation = 0,0,0
+        localPosition = 0,0,0.2
+        fixedScale = 1
+        energy = 1
+        speed = 1
+    }
+
+    @MODULE[ModuleEngineConfigs] {
+        @CONFIG[UDMH+NTO] {
+            %powerEffectName = Hypergolic-Lower
+        }
+        @CONFIG[Kerosene+LqdOxygen] {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/Squad.cfg
+++ b/GameData/RealPlume-RFStockalike/Squad.cfg
@@ -487,10 +487,10 @@
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
         localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,-0.33           //Any offset needed
+        //localPosition = 0,0,0.33           //Any offset needed
         //flare|plumePosition are optional, and conflict with localPosition.
-      //flarePosition = 0,0,1         //If localPosition is insufficient
-      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        flarePosition = 0,0,1.1         //If localPosition is insufficient
+        plumePosition = 0,0,0.33 //Specify flare and plume positions separately.
         //Only specify one of these
         fixedScale = 2                  //Size adjustment to resize to engine
         energy = 1                      //Adjust length of plume


### PR DESCRIPTION
I've added RealPlume settings for all of the engines in HGR. Along the way, I updated the names of a couple of engines that got renamed in HGR since they were first added to Stockalike.

While I was working on plumes, I also adjusted the plume location on the Squad LV-909 "Terrier" to fix an issue that's been reported on the forum.