### PR TITLE
Fix part categories for KW engines

### DIFF
--- a/GameData/RealFuels-Stockalike/fix-part-categories.cfg
+++ b/GameData/RealFuels-Stockalike/fix-part-categories.cfg
@@ -6,3 +6,7 @@
 @PART[*]:HAS[#category[Propulsion],@MODULE[ModuleEnginesRF]]:FINAL {
     @category = Engine
 }
+
+@PART[*]:HAS[#category[0],@MODULE[ModuleEnginesRF]]:FINAL {
+    @category = Engine
+}


### PR DESCRIPTION
After I submitted the patch to properly categorize engines with `category = Propulsion`, I found that KW Rocketry's engines are using `category = 0` instead. Because of that quirk, they're still showing up as fuel tanks even after the previous patch.

This pull extends my previous patch to handle properly categorizing the KW engines.