### PR TITLE
RealPlume configs

### DIFF
--- a/GameData/RealPlume-RFStockalike/AIES.cfg
+++ b/GameData/RealPlume-RFStockalike/AIES.cfg
@@ -38,7 +38,7 @@
     @MODULE[ModuleEngineConfigs]
     {
         %type = ModuleEnginesRF
-        @CONFIG[MMH+NTO]  //Add the effect to every engine config
+        @CONFIG[UDMH+NTO]  //Add the effect to every engine config
         {
             %powerEffectName = Hypergolic-Lower
         }

--- a/GameData/RealPlume-RFStockalike/CMES.cfg
+++ b/GameData/RealPlume-RFStockalike/CMES.cfg
@@ -1,0 +1,210 @@
+@PART[XSLSSRB]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / SRB for SLS
+{
+    PLUME
+    {
+        name = Solid-Lower            //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Solid-Lower
+        }
+    }
+}
+@PART[XXxAres1J2-XHIGH]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / J2-X
+{
+    PLUME
+    {
+        name = Hydrolox-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}
+@PART[nervaII_kerbscalexx]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / NERVA II
+{
+    PLUME
+    {
+        name = Hydrogen-NTR           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrogen-NTR
+        }
+    }
+}
+@PART[XKosmos_TKS_RD-0225_EngineLANDERS]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / ROVER TERMINAL RETRO
+{
+    PLUME
+    {
+        name = Hypergolic-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}
+@PART[XKosmos_Angara_RD-275KX]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / KOCMOC RD-586
+{
+    PLUME
+    {
+        name = Hypergolic-Upper		//pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[xbahars68bx]:FOR[RealPlume]:NEEDS[SmokeScreen] //Chaka / RS-68C
+{
+    PLUME
+    {
+        name = Hydrolox-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}
+@PART[XROVERENGINE]:FOR[RealPlume]:NEEDS[SmokeScreen] //CHAKA / Terminal Retro Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/FASA.cfg
+++ b/GameData/RealPlume-RFStockalike/FASA.cfg
@@ -1,0 +1,420 @@
+@PART[FASAApolloLFEH1]:FOR[RealPlume]:NEEDS[SmokeScreen] // Apollo H-1 Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+@PART[FASAApolloLFEJ2]:FOR[RealPlume]:NEEDS[SmokeScreen] // Apollo J2 Engine
+{
+    PLUME
+    {
+        name = Hydrolox-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+@PART[FASAApolloLFERL10]:FOR[RealPlume]:NEEDS[SmokeScreen] // Gemini Centaur RL-10 Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper        //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0.75           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASALM_AscentEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] // Apollo LEM Ascent Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper       //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,1           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 0.75                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASALM_DescentEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] // Apollo LEM Descent Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,1.25           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASA_Gemini_Lander_Eng]:FOR[RealPlume]:NEEDS[SmokeScreen] // Gemini Lander Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Lower       //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,3           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 0.125                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}
+@PART[FASAGeminiLR87Twin]:FOR[RealPlume]:NEEDS[SmokeScreen] // Gemini Titan LR-87 Twin Rocket Engines
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+@PART[FASAGeminiLR91Mini]:FOR[RealPlume]:NEEDS[SmokeScreen] // Gemini LR-91 Mini Rocket Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0.5           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASAGemini4X800Mini]:FOR[RealPlume]:NEEDS[SmokeScreen] // Gemini Mini X-800 Rocket Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper        //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,1           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASAMercuryAtlasEngBooster]:FOR[RealPlume]:NEEDS[SmokeScreen] // Mercury Atlas Booster Rocket Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}
+@PART[FASA_Mercury_Eng]:FOR[RealPlume]:NEEDS[SmokeScreen] // Mercury Retro Rocket Engine pack
+{
+    PLUME
+    {
+        name = Solid-Upper        //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Solid-Upper
+        }
+    }
+}
+@PART[FASA_Mercury_LFEng]:FOR[RealPlume]:NEEDS[SmokeScreen] // Mercury Liquid Fuelled Retro Rocket Engine pack
+{
+    PLUME
+    {
+        name = Hypergolic-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 0.125                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[FASA_Mercury_Redstone_Eng]:FOR[RealPlume]:NEEDS[SmokeScreen] // Mercury Redstone A-6 Rocket Engine
+{
+    PLUME
+    {
+        name = Alcolox-Lower-A6         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,1           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Alcolox-Lower-A6
+        }
+    }
+}
+@PART[FASAMercuryAtlasEng]:FOR[RealPlume]:NEEDS[SmokeScreen] // Mercury Atlas Rocket Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/FASA.cfg
+++ b/GameData/RealPlume-RFStockalike/FASA.cfg
@@ -310,7 +310,7 @@
       //flarePosition = 0,0,1         //If localPosition is insufficient
       //plumePosition = 0,0,2         //Specify flare and plume positions separately.
         //Only specify one of these
-        fixedScale = 1                  //Size adjustment to resize to engine
+        fixedScale = 0.125                  //Size adjustment to resize to engine
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.

--- a/GameData/RealPlume-RFStockalike/KOSMOS.cfg
+++ b/GameData/RealPlume-RFStockalike/KOSMOS.cfg
@@ -1,0 +1,180 @@
+@PART[Kosmos_Angara_RD-33NK]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-33NK
+{
+    PLUME
+    {
+        name = Hydrolox-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}
+@PART[Kosmos_RD-58SS]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-58SS
+{
+    PLUME
+    {
+        name = Kerolox-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}
+@PART[Kosmos_Angara_RD-0146]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0146D
+{
+    PLUME
+    {
+        name = Hypergolic-Upper          //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[Kosmos_Angara_RD-0146N2]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-0146-N2
+{
+    PLUME
+    {
+        name = Hypergolic-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[Kosmos_Angara_RD-275K]:FOR[RealPlume]:NEEDS[SmokeScreen] //RD-275K
+{
+    PLUME
+    {
+        name = Hypergolic-Lower          //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}
+@PART[Kosmos_TKS_RD-0225_Engine]:FOR[RealPlume]:NEEDS[SmokeScreen] //TKS RD-0225 Monopropellant Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/KSPX.cfg
+++ b/GameData/RealPlume-RFStockalike/KSPX.cfg
@@ -1,0 +1,30 @@
+@PART[cl_large_nuclearEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] //LV-NB "Sisyphus" Atomic Rocket Motor
+{
+    PLUME
+    {
+        name = Hydrogen-NTR           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrogen-NTR
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/KlockheedMartian.cfg
+++ b/GameData/RealPlume-RFStockalike/KlockheedMartian.cfg
@@ -1,0 +1,30 @@
+@PART[km_se4L]:FOR[RealPlume]:NEEDS[SmokeScreen] //FSX4L Linear Aerospike
+{
+    PLUME
+    {
+        name = Kerolox-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/LBSI.cfg
+++ b/GameData/RealPlume-RFStockalike/LBSI.cfg
@@ -1,0 +1,239 @@
+@PART[LBSI-ENG-MPt180-HB]:FOR[RealPlume]:NEEDS[SmokeScreen] //LBSI MPt-180 "humming-bird" MonoFuel-Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Lower
+        }
+    }
+}
+@PART[LBSI-SB-FRT360]:FOR[RealPlume]:NEEDS[SmokeScreen] //LBSI SB FRT-360 Solid Fuel Booster
+{
+    PLUME
+    {
+        name = Solid-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Solid-Lower
+        }
+    }
+}
+@PART[LBSI-ENG-LAE-250M]:FOR[RealPlume]:NEEDS[SmokeScreen] //LAE-250M lateral Advanced Monopropellant Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[LBSI-ENG-BPt180-HB]:FOR[RealPlume]:NEEDS[SmokeScreen] //LBSI BPt-180 "humming-bird" LiquidFuel-Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}
+@PART[LBSI-ENG-LAE-250]:FOR[RealPlume]:NEEDS[SmokeScreen] //LAE-250 lateral Advanced Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Hydrolox-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Upper
+        }
+    }
+}
+@PART[LBSI-ENG-WPt500-SkyWipe]:FOR[RealPlume]:NEEDS[SmokeScreen] //LBSI WPt x500 "SkyWipe" - Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Kerolox-Upper         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Upper
+        }
+    }
+}
+@PART[LBSI-ENG-WPt1200-SkyWipe]:FOR[RealPlume]:NEEDS[SmokeScreen] //LBSI WPt x1200 "SkyWipe" - Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+    }
+}
+@PART[LBSI-ENG-WPt2800-SkyWipe]:FOR[RealPlume]:NEEDS[SmokeScreen] // LBSI WPt x2800 "SkyWipe"- Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Kerolox-Lower         //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Kerolox-Lower
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/RSCapsuledyne.cfg
+++ b/GameData/RealPlume-RFStockalike/RSCapsuledyne.cfg
@@ -1,0 +1,30 @@
+@PART[TaurusOrbitalEngine]:FOR[RealPlume]:NEEDS[SmokeScreen] //RKMX-4 'Quadroodle' Liquid Fuel Engine
+{
+    PLUME
+    {
+        name = Hypergolic-Upper           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-Upper
+        }
+    }
+}

--- a/GameData/RealPlume-RFStockalike/RSCapsuledyne.cfg
+++ b/GameData/RealPlume-RFStockalike/RSCapsuledyne.cfg
@@ -5,7 +5,7 @@
         name = Hypergolic-Upper           //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
         localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0,0           //Any offset needed
+        localPosition = 0,0,0.625           //Any offset needed
         //flare|plumePosition are optional, and conflict with localPosition.
       //flarePosition = 0,0,1         //If localPosition is insufficient
       //plumePosition = 0,0,2         //Specify flare and plume positions separately.

--- a/GameData/RealPlume-RFStockalike/Vanguard.cfg
+++ b/GameData/RealPlume-RFStockalike/Vanguard.cfg
@@ -1,0 +1,30 @@
+@PART[VADLanderspike125]:FOR[RealPlume]:NEEDS[SmokeScreen] //VX-LS01 "Landerspike" Advanced Aerospike Engine
+{
+    PLUME
+    {
+        name = Hydrolox-Lower           //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+        localPosition = 0,0,0           //Any offset needed
+        //flare|plumePosition are optional, and conflict with localPosition.
+      //flarePosition = 0,0,1         //If localPosition is insufficient
+      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
+        //Only specify one of these
+        fixedScale = 1                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+        @CONFIG,*   //Add the effect to every engine config
+        {
+            %powerEffectName = Hydrolox-Lower
+        }
+    }
+}


### PR DESCRIPTION
RSCapsuledyne
KOSMOS
Klockheed Martian
Chaka Monkey
FASA
LBSI
Vanguard (added Landerspike)
KSPX (added nuke)
AIES (fixed VR-1 plume)

Some engine plumes (1x Klockheed, 3x FASA, 5x KOSMOS) are still missing. I believe that this is due to a problem with their RFStockalike configs. Working on it.
