### PR TITLE
Free ignition for USI DERP

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_Umbra.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_Umbra.cfg
@@ -243,14 +243,9 @@
 			IspSL = 0.2740
 			IspV = 0.7200
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -267,14 +262,9 @@
 			IspSL = 0.1770
 			IspV = 0.4650
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -297,14 +287,9 @@
 			IspSL = 0.9500
 			IspV = 0.9500
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -327,24 +312,14 @@
 			IspSL = 0.9600
 			IspV = 0.9500
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 	}
-	ignitions = 24
+	ignitions = 0
 	ullage = false
 	pressureFed = true
-	IGNITOR_RESOURCE
-	{
-		name = ElectricCharge
-		amount = 0.04
-	}
 }
 
 @PART[DERP_Engine_02]:FOR[RealFuels_StockEngines] //DERP Inline MonoPropellant Engine
@@ -402,14 +377,9 @@
 			IspSL = 0.2740
 			IspV = 0.7200
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -426,14 +396,9 @@
 			IspSL = 0.1770
 			IspV = 0.4650
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -456,14 +421,9 @@
 			IspSL = 0.9500
 			IspV = 0.9500
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 		CONFIG
 		{
@@ -486,24 +446,14 @@
 			IspSL = 0.9600
 			IspV = 0.9500
 			throttle = 0
-			ignitions = 24
+			ignitions = 0
 			ullage = false
 			pressureFed = true
-			IGNITOR_RESOURCE
-			{
-				name = ElectricCharge
-				amount = 0.04
-			}
 		}
 	}
-	ignitions = 24
+	ignitions = 0
 	ullage = false
 	pressureFed = true
-	IGNITOR_RESOURCE
-	{
-		name = ElectricCharge
-		amount = 0.04
-	}
 
 	!RESOURCE[LiquidFuel] {}
 	!RESOURCE[Oxidizer] {}

--- a/GameData/RealFuels-Stockalike/Stockalike_Umbra.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_Umbra.cfg
@@ -244,7 +244,7 @@
 			IspV = 0.7200
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -268,7 +268,7 @@
 			IspV = 0.4650
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -298,7 +298,7 @@
 			IspV = 0.9500
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -328,7 +328,7 @@
 			IspV = 0.9500
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -338,7 +338,7 @@
 		}
 	}
 	ignitions = 24
-	ullage = true
+	ullage = false
 	pressureFed = true
 	IGNITOR_RESOURCE
 	{
@@ -403,7 +403,7 @@
 			IspV = 0.7200
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -427,7 +427,7 @@
 			IspV = 0.4650
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -457,7 +457,7 @@
 			IspV = 0.9500
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -487,7 +487,7 @@
 			IspV = 0.9500
 			throttle = 0
 			ignitions = 24
-			ullage = true
+			ullage = false
 			pressureFed = true
 			IGNITOR_RESOURCE
 			{
@@ -497,7 +497,7 @@
 		}
 	}
 	ignitions = 24
-	ullage = true
+	ullage = false
 	pressureFed = true
 	IGNITOR_RESOURCE
 	{


### PR DESCRIPTION
The DERP escape-pod parts from the USI Survivability Pack are designed to fit together into an easy-to-build, low-part-count space lifeboat. But the configuration that's obvious in the stock game doesn't lend itself to installing RCS thrusters in places that are useful for ullage.

That makes the pack's small monopropellant engines good candidates to be classified as "functionally no different from a large RCS thruster" and set to no ullage requirement and unlimited ignitions.