### PR TITLE
SXT AJ-10 – use both of the available models

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
@@ -369,7 +369,7 @@
 
     ignitions = 4
     ullage = true
-		pressureFed = true
+    pressureFed = true
   }
 
   MODULE
@@ -405,9 +405,9 @@
       IspV = 0.9885
       throttle = 0
 
-			ignitions = 4
-			ullage = true
-			pressureFed = true
+      ignitions = 4
+      ullage = true
+      pressureFed = true
 
     }
     CONFIG
@@ -432,9 +432,9 @@
       IspV = 1.0485
       throttle = 0
 
-			ignitions = 4
-			ullage = true
-			pressureFed = true
+      ignitions = 4
+      ullage = true
+      pressureFed = true
 
     }
   }
@@ -460,7 +460,7 @@
   @MODULE[ModuleEngine*]
   {
     @name = ModuleEnginesRF
-    @maxThrust = 10
+    @maxThrust = 15.5
     @heatProduction = 83
     @atmosphereCurve
     {
@@ -484,9 +484,8 @@
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
 
-		ullage = true
-		pressureFed = true
-		ignitions = -1
+    ullage = true
+    pressureFed = true
   }
 
   MODULE
@@ -503,7 +502,7 @@
     CONFIG
     {
       name = UDMH+IRFNA-III
-      maxThrust = 10
+      maxThrust = 15.5
       heatProduction = 83
       PROPELLANT
       {
@@ -522,14 +521,13 @@
       IspV = 0.9885
       throttle = 0
 
-			ullage = true
-			pressureFed = true
-			ignitions = -1
+      ullage = true
+      pressureFed = true
     }
     CONFIG
     {
       name = Aerozine50+NTO
-      maxThrust = 10
+      maxThrust = 15.5
       heatProduction = 83
       PROPELLANT
       {
@@ -548,9 +546,8 @@
       IspV = 1.0485
       throttle = 0
 
-			ullage = true
-			pressureFed = true
-			ignitions = -1
+      ullage = true
+      pressureFed = true
 
     }
   }
@@ -559,12 +556,14 @@
 
 // Since we've made the SXT AJ-10 pressure-fed, the SXT 0.625m fuel tank gets
 // a tank type that can support a pressure-fed engine.
-@PART[SXTFuel625m]:AFTER[RealFuels]
+@PART[SXT625mFuel4]:FOR[RealFuels_StockEngines]
 {
-	@MODULE[ModuleFuelTanks]
-	{
-		@type = ServiceModule
-	}
+  MODULE
+  {
+    name = ModuleFuelTanks
+    volume = 600
+    type = ServiceModule
+  }
 }
 
 @PART[SXTX405]:FOR[RealFuels_StockEngines] //KX-405 Liquid Fuel Engine

--- a/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
@@ -348,7 +348,7 @@
     @atmosphereCurve
     {
       @key,0 = 0 257
-      @key,1 = 1 91
+      @key,1 = 1 227
     }
     !PROPELLANT[LiquidFuel] {}
     !PROPELLANT[Oxidizer] {}
@@ -366,6 +366,10 @@
       ratio = 54.394169
       %resourceFlowMode = STACK_PRIORITY_SEARCH
     }
+
+    ignitions = 4
+    ullage = true
+		pressureFed = true
   }
 
   MODULE
@@ -374,7 +378,7 @@
     type = ModuleEnginesRF
     techLevel = 0
     origTechLevel = 0
-    engineType = O
+    engineType = L
     origMass = 0.054
     configuration = UDMH+IRFNA-III
     modded = false
@@ -397,22 +401,13 @@
         ratio = 54.39416861504607
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
-      IspSL = 0.9100
-      IspV = 0.9000
+      IspSL = 0.9701
+      IspV = 0.9885
       throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.1
-        }
-      }
 
+			ignitions = 4
+			ullage = true
+			pressureFed = true
 
     }
     CONFIG
@@ -433,36 +428,145 @@
         ratio = 51.34228187919462
         %resourceFlowMode = STACK_PRIORITY_SEARCH
       }
-      IspSL = 0.9600
-      IspV = 0.9500
+      IspSL = 1.0201
+      IspV = 1.0485
       throttle = 0
-      ModuleEngineIgnitor
-      {
-        ignitionsAvailable = 24
-        useUllageSimulation = true
-        autoIgnitionTemperature = 800
-        ignitorType = Electric
-        IGNITOR_RESOURCE
-        {
-          name = ElectricCharge
-          amount = 0.1
-        }
-      }
 
+			ignitions = 4
+			ullage = true
+			pressureFed = true
 
     }
   }
   !MODULE[ModuleEngineIgnitor] {}
-  ModuleEngineIgnitor
-  {
-    ignitionsAvailable = 24
-    autoIgnitionTemperature = 800
-    useUllageSimulation = true
-
-  }
-
 
 }
+@PART[SXTAJ10Mid]:FOR[RealFuels_StockEngines] //KJ10-104 Liquid Fuel Engine
+{
+    // SXT includes a second AJ10 model with a longer nozzle. This part is
+    // hidden by default, but Realism Overhaul uses it for some later AJ10
+    // variants. 
+
+  @category = Engine
+  %TechRequired = advRocketry
+  @title = LV-10-104 "Rearguard-B" Liquid Fuel Engine
+
+  @mass = 0.6
+  @cost = 85
+  %entryCost = 425
+  @maxTemp = 2400
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 10
+    @heatProduction = 83
+    @atmosphereCurve
+    {
+      @key,0 = 0 331
+      @key,1 = 1 195
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = UDMH
+      ratio = 45.605831
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = IRFNA-III
+      ratio = 54.394169
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+
+		ullage = true
+		pressureFed = true
+		ignitions = -1
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 3
+    origTechLevel = 3
+    engineType = U
+    origMass = 0.6
+    configuration = UDMH+IRFNA-III
+    modded = false
+
+    CONFIG
+    {
+      name = UDMH+IRFNA-III
+      maxThrust = 10
+      heatProduction = 83
+      PROPELLANT
+      {
+        name = UDMH
+        ratio = 45.60583138495393
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = IRFNA-III
+        ratio = 54.39416861504607
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9701
+      IspV = 0.9885
+      throttle = 0
+
+			ullage = true
+			pressureFed = true
+			ignitions = -1
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 10
+      heatProduction = 83
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 48.65771812080538
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 51.34228187919462
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0201
+      IspV = 1.0485
+      throttle = 0
+
+			ullage = true
+			pressureFed = true
+			ignitions = -1
+
+    }
+  }
+  !MODULE[ModuleEngineIgnitor] {}
+}
+
+// Since we've made the SXT AJ-10 pressure-fed, the SXT 0.625m fuel tank gets
+// a tank type that can support a pressure-fed engine.
+@PART[SXTFuel625m]:AFTER[RealFuels]
+{
+	@MODULE[ModuleFuelTanks]
+	{
+		@type = ServiceModule
+	}
+}
+
 @PART[SXTX405]:FOR[RealFuels_StockEngines] //KX-405 Liquid Fuel Engine
 {
 

--- a/GameData/RealPlume-RFStockalike/SXT.cfg
+++ b/GameData/RealPlume-RFStockalike/SXT.cfg
@@ -5,12 +5,39 @@
         name = Hypergolic-OMS-White            //pre-fabbed plume you want
         transformName = thrustTransform //which transform to attach the plume
         localRotation = 0,0,0           //Optional - Any rotation needed
-        localPosition = 0,0.01,-1.95     //Any offset needed
-        //flare|plumePosition are optional, and conflict with localPosition.
-      //flarePosition = 0,0,1         //If localPosition is insufficient
-      //plumePosition = 0,0,2         //Specify flare and plume positions separately.
-        //Only specify one of these
-        fixedScale = 1                  //Size adjustment to resize to engine
+
+        flarePosition = 0,0,-1.75
+        plumePosition = 0,0,0
+        fixedScale = 0.25                  //Size adjustment to resize to engine
+        energy = 1                      //Adjust length of plume
+        speed = 1                       //Adjust speed to fit resize, 
+                                        //generally close to 1:1 with scale.
+    }
+    @MODULE[ModuleEngines*]
+    {
+        @name = ModuleEnginesRF
+		// =  Hypergolic-OMS-White
+    }
+    @MODULE[ModuleEngineConfigs]
+    {
+        %type = ModuleEnginesRF
+		@CONFIG,*  //Add the effect to every engine config
+        {
+            %powerEffectName = Hypergolic-OMS-White
+        }
+    }
+}
+@PART[SXTAJ10Mid]:BEFORE[RealPlume]
+{
+	PLUME
+    {
+        name = Hypergolic-OMS-White            //pre-fabbed plume you want
+        transformName = thrustTransform //which transform to attach the plume
+        localRotation = 0,0,0           //Optional - Any rotation needed
+
+        flarePosition = 0,0,-1.75
+        plumePosition = 0,0,0
+        fixedScale = 0.25                  //Size adjustment to resize to engine
         energy = 1                      //Adjust length of plume
         speed = 1                       //Adjust speed to fit resize, 
                                         //generally close to 1:1 with scale.


### PR DESCRIPTION
SXT includes a second version of its AJ-10 engine ("LV-10-37 'Rearguard'" in-game) with a longer nozzle. The alternate model has a part config that the game loads, but it isn't assigned to a VAB category unless you're using Realism Overhaul.

Here's my take on a set of RFStockalike configs that use both models.

* The short-nozzle model that was previously configured keeps the same thrust and vacuum Isp as before. Its engine category changes from "O" to "L" to bring its sea-level Isp closer to what Realism Overhaul has for the AJ-10-37.

   * Available ignitions decrease from 24 to 4. All of the short-nozzle AJ-10 variants in Realism Overhaul are limited to one ignition, but I felt that in Stockalike, it still needs a few restarts for people who are playing at stock or 3.2x scale and have a coast to apoapsis in their ascent profiles.

* The long-nozzle model becomes available at tech level 3. It has a bit more mass than the short-nozzle engine, but offers about 8% better thrust and vacuum Isp than the short-nozzle variant does at tech level 3.

* All of the AJ-10 variants that use the long-nozzle model in Realism Overhaul have unlimited ignitions, so I gave the long-nozzle engine unlimited ignitions in Stockalike.

* Both engines are set to pressure-fed, like the real AJ-10. The SXT Oscar-C fuel tank (0.625m diameter by 2.5m long) is changed to tank type ServiceModule so it can support pressure-fed engines.

* RealPlume settings are adjusted for both models so the plume appears to originate from inside the nozzle instead of from the sides of the combustion chamber.