### PR TITLE
SXT long-nozzle AJ10 was supposed to be 60 kg, not 600.

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
@@ -451,7 +451,7 @@
   %TechRequired = advRocketry
   @title = LV-10-104 "Rearguard-B" Liquid Fuel Engine
 
-  @mass = 0.6
+  @mass = 0.06
   @cost = 85
   %entryCost = 425
   @maxTemp = 2400

--- a/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_SXT.cfg
@@ -495,7 +495,7 @@
     techLevel = 3
     origTechLevel = 3
     engineType = U
-    origMass = 0.6
+    origMass = 0.06
     configuration = UDMH+IRFNA-III
     modded = false
 


### PR DESCRIPTION
When I contributed the config for the SXT long-nozzle AJ10, I meant to set the mass to 60 kg. I just noticed that I was missing a zero and that engine has been at 600 kg. This fix should restore performance to what I had in mind.