### PR TITLE
Remove :FINAL patches

### DIFF
--- a/GameData/RealFuels-Stockalike/Fuel_Conversions.cfg
+++ b/GameData/RealFuels-Stockalike/Fuel_Conversions.cfg
@@ -5,7 +5,7 @@
 // Made to look user-friendly for any looking to pull from or alter while also removing outdated errors from previous versions of RealFuels and Module Manager
 // Abstract: changes basic fuel tanks to use RealFuels resources, also makes RCS Thrusters use Hydrazine
 
-@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:Final    // Turns tanks with LiquidFuel and Oxidizer as resources into ModuleFuelTanks
+@PART[*]:HAS[@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]    // Turns tanks with LiquidFuel and Oxidizer as resources into ModuleFuelTanks
 {
   MODULE
   {
@@ -26,7 +26,7 @@
   }
 }
 
-@PART[*]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:Final    // Changes any tanks with just LiquidFuel, aircraft parts basically, and replaces with ModuleFuelTanks
+@PART[*]:HAS[@RESOURCE[LiquidFuel],!RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]    // Changes any tanks with just LiquidFuel, aircraft parts basically, and replaces with ModuleFuelTanks
 {
   MODULE
   {
@@ -42,7 +42,7 @@
   }
 }
 
-@PART[*]:HAS[@RESOURCE[MonoPropellant],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:Final    // Does exact same process above except for RCS tanks
+@PART[*]:HAS[@RESOURCE[MonoPropellant],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]    // Does exact same process above except for RCS tanks
 {
   MODULE
   {
@@ -58,7 +58,7 @@
   }
 }
 
-@PART[*]:HAS[@RESOURCE[MonoPropellant],@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:Final    // Any tanks with all 3 resources, i.e. Service Modules, replaces with 1 tank for RCS fuel and another for Fuel
+@PART[*]:HAS[@RESOURCE[MonoPropellant],@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer],!MODULE[ModuleFuelTanks],!MODULE[ModuleCommand]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]    // Any tanks with all 3 resources, i.e. Service Modules, replaces with 1 tank for RCS fuel and another for Fuel
 {
   MODULE
   {
@@ -84,7 +84,7 @@
   }
 }
 
-@PART[*]:HAS[@MODULE[ModuleRCS*]:HAS[#resourceName[MonoPropellant]]]:NEEDS[RealFuels]:Final    // turns all RCS thrusters not explicitly changed to use Hydrazine instead of MonoPropellant
+@PART[*]:HAS[@MODULE[ModuleRCS*]:HAS[#resourceName[MonoPropellant]]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]    // turns all RCS thrusters not explicitly changed to use Hydrazine instead of MonoPropellant
 {
   @MODULE[ModuleRCS*]            // searches for and prepares to alter modules beginning with ModuleRCS, beginning because it will also include modules of ModuleRCS if that mod is installed
   {
@@ -93,7 +93,7 @@
 }
 
 // If we already have an MFT in the part (i.e. with TACLS) then add volume and change to a ServiceModule tank
-@PART[*]:HAS[@MODULE[ModuleCommand],@RESOURCE[MonoPropellant],@RESOURCE[ElectricCharge],@MODULE[ModuleFuelTanks],#CrewCapacity[*],~CrewCapacity[0]]:NEEDS[RealFuels,TacLifeSupport]:Final
+@PART[*]:HAS[@MODULE[ModuleCommand],@RESOURCE[MonoPropellant],@RESOURCE[ElectricCharge],@MODULE[ModuleFuelTanks],#CrewCapacity[*],~CrewCapacity[0]]:NEEDS[RealFuels,TacLifeSupport]:FOR[z_RealFuels_StockEngines]
 {
   @MODULE[ModuleFuelTanks]
   {
@@ -177,7 +177,7 @@
 }
 
 // If we don't have a MFT yet (i.e. no TACLS), make one
-@PART[*]:HAS[@MODULE[ModuleCommand],@RESOURCE[MonoPropellant],@RESOURCE[ElectricCharge],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[ModuleCommand],@RESOURCE[MonoPropellant],@RESOURCE[ElectricCharge],!MODULE[ModuleFuelTanks]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
   MODULE
   {

--- a/GameData/RealFuels-Stockalike/Jet_modularEngines.cfg
+++ b/GameData/RealFuels-Stockalike/Jet_modularEngines.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[LiquidFuel]]:Final
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[LiquidFuel]]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[ModuleEngines*],*
 	{
@@ -10,7 +10,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[Oxidizer]]:Final
+@PART[*]:HAS[@MODULE[ModuleEngines*]]:HAS[@PROPELLANT[Oxidizer]]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[ModuleEngines*],*
 	{
@@ -23,7 +23,7 @@
 }
 
 // Replaces any stock LiquidFuel/Oxidizer in Firespitter Parts
-@PART[*]:HAS[@MODULE[FSEngine]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[FSEngine]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[FSEngine]
 	{
@@ -33,7 +33,7 @@
 }
 
 // Replaces stock fuels for FS helicopter parts
-@PART[*]:HAS[@MODULE[FSengineBladed]]:NEEDS[RealFuels]:Final
+@PART[*]:HAS[@MODULE[FSengineBladed]]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
 	@MODULE[FSEngine]
 	{

--- a/GameData/RealFuels-Stockalike/StockAlike_RCS_RF.cfg
+++ b/GameData/RealFuels-Stockalike/StockAlike_RCS_RF.cfg
@@ -7877,7 +7877,7 @@
 
 }
 
-@PART[vernierEngine]:NEEDS[RealFuels]:FINAL
+@PART[vernierEngine]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
     @MODULE[ModuleRCS]
     {
@@ -8010,7 +8010,7 @@
     }
 }
 
-@PART[LazTekUltraDracoRCSNacelle]:NEEDS[RealFuels]:FINAL
+@PART[LazTekUltraDracoRCSNacelle]:NEEDS[RealFuels]:FOR[z_RealFuels_StockEngines]
 {
     @MODULE[ModuleRCS]
     {

--- a/GameData/RealFuels-Stockalike/Stockalike_NFPropulsion.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_NFPropulsion.cfg
@@ -20,7 +20,7 @@
 	}
 }
 
-@PART[ionEngine]:NEEDS[RealFuels,NearFuturePropulsion]:FINAL //Too many mods attempting to change this engine, cleanup.
+@PART[ionEngine]:NEEDS[RealFuels,NearFuturePropulsion]:FOR[z_RealFuels_StockEngines] //Too many mods attempting to change this engine, cleanup.
 {
 	@MODULE[ModuleEnginesFX]
 	{

--- a/GameData/RealFuels-Stockalike/fix-part-categories.cfg
+++ b/GameData/RealFuels-Stockalike/fix-part-categories.cfg
@@ -3,10 +3,10 @@
 // Because the auto-sort doesn't recognize ModuleEnginesRF as an engine module,
 //  we need ModuleManager to do the sort for us.
 
-@PART[*]:HAS[#category[Propulsion],@MODULE[ModuleEnginesRF]]:FINAL {
+@PART[*]:HAS[#category[Propulsion],@MODULE[ModuleEnginesRF]]:FOR[z_RealFuels_StockEngines] {
     @category = Engine
 }
 
-@PART[*]:HAS[#category[0],@MODULE[ModuleEnginesRF]]:FINAL {
+@PART[*]:HAS[#category[0],@MODULE[ModuleEnginesRF]]:FOR[z_RealFuels_StockEngines]L {
     @category = Engine
 }

--- a/GameData/zzRFStockalike/zzRFStockalike_SDHI.cfg
+++ b/GameData/zzRFStockalike/zzRFStockalike_SDHI.cfg
@@ -1,5 +1,5 @@
 // SDHI Overrides
-@PART[Mark1-2Pod]:NEEDS[RealFuels,SDHI,TacLifeSupport]:Final
+@PART[Mark1-2Pod]:NEEDS[RealFuels,SDHI,TacLifeSupport]:FOR[z_RealFuels_StockEngines]
 {
   !MODULE[ModuleFuelTanks],*{} // Nuke all MFTs for good measure at this point
   MODULE


### PR DESCRIPTION
No patches in a distributed mod should be :FINAL, this prevents any
other patches from being run after them, and the :FINAL pass is usually
reserved for personal patches that won't be distributed