### PR TITLE
Update Squad_NTR_modularEngines.cfg

### DIFF
--- a/GameData/RealFuels-Stockalike/Squad_NTR_modularEngines.cfg
+++ b/GameData/RealFuels-Stockalike/Squad_NTR_modularEngines.cfg
@@ -25,6 +25,7 @@
 
     @MODULE[ModuleEngines*]
     {
+        @name = ModuleEnginesRF
         PROPELLANT
         {
             name = LqdHydrogen
@@ -49,7 +50,7 @@
 
     MODULE
     {
-            name = ModuleEnginesFX
+            name = ModuleEnginesRF
             engineID = Afterburner
             directThrottleEffectName = powerflame
             runningEffectName = powersmoke
@@ -137,92 +138,5 @@
         name = DepletedUranium
         amount = 0
         maxAmount = 5
-    }
-    MODULE
-    {
-        name = ModuleHybridEngine
-        type = ModuleEnginesFX
-        configuration = Hydrogen
-        techLevel = 5
-        origTechLevel = 5
-        maxTechLevel = 8
-        engineType = N
-        //origMass = 6.8
-        CONFIG
-        {
-            name = Hydrogen
-            thrustVectorTransformName = thrustTransform
-            exhaustDamage = True
-            ignitionThreshold = 0.1
-            minThrust = 0
-            maxThrust = 111.2
-            heatProduction = 300
-            fxOffset = 0, 0, 1.0
-            PROPELLANT
-            {
-                name = LqdHydrogen
-                ratio = 1.0
-                DrawGauge = True
-                %resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
-            PROPELLANT
-            {
-                name = EnrichedUranium
-                ratio = 0.00000000001
-            }
-            atmosphereCurve
-            {
-                key = 0 925
-                key = 1 556
-            }
-            IspSL = 1.016483516483516
-            IspV = 1.016483516483516
-        }
-        CONFIG
-        {
-            name = LqdHydrogen+LqdOxygen
-            thrustVectorTransformName = thrustTransform
-            exhaustDamage = True
-            ignitionThreshold = 0.1
-            minThrust = 0
-            maxThrust = 303.9466
-            heatProduction = 325
-            fxOffset = 0, 0, 1.0
-            // Assuming LOX / H2 ratio of 3-1 (mass)
-            //        0.6941 Isp
-            // volume ratio conversion
-            // 1.141 kg LOX (1L) x3
-            //
-            // 1.141 kg LH2 (16.10444601270289L)
-            // mixture ratio by mass:
-            // = 0.003423 kg O2
-            // = 0.001141 H2
-            PROPELLANT
-            {
-                name = LqdHydrogen
-                ratio = 16.10444601270289
-                DrawGauge = True
-                %resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
-            PROPELLANT
-            {
-                name = LqdOxygen
-                ratio =  3.0
-                DrawGauge = False
-                %resourceFlowMode = STACK_PRIORITY_SEARCH
-            }
-            PROPELLANT
-            {
-                name = EnrichedUranium
-                ratio = 0.00000000001
-            }
-            atmosphereCurve
-            {
-                key = 0 642
-                key = 1 386
-            }
-            IspSL = 0.6941
-            IspV = 0.6941
-        }
     }
 }


### PR DESCRIPTION
ModuleHybridEngine should not be used with MultiModeEngine. It's duplicated functionality AND ModuleHybridEngine is also somewhat outdated anyway. I can't see a need for it unless you want to be able to configure an engine for multiple propellants AND also have each config support afterburner mode. (I think that is possible but not quite sure and these configs don't attempt that anyway).

History: ModuleHybridEngine is an extension of ModuleEngineConfigs that provided multi mode support before MultiModeEngine module was added to stock. It's somewhat obsolete except for the aforementioned possibility of creating multiple propellant/afterburner combinations. Assuming that actually works...