### PR TITLE
Plume for 1.6 reskins and making history engines

### DIFF
--- a/GameData/RealPlume-RFStockalike/Squad.cfg
+++ b/GameData/RealPlume-RFStockalike/Squad.cfg
@@ -1224,3 +1224,493 @@
 		%powerEffectName = Ion-Xenon-Hall
 	}
 }
+
+@PART[liquidEngine3_v2]:BEFORE[RealPlume] // LV-909 "Terrier V2" (Reskin from update 1.6)
+{
+	PLUME
+	{
+		name = Hypergolic-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.5
+		plumePosition = 0,0,0.3
+		fixedScale = 0.8
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.75
+		plumePosition = 0,0,1
+		fixedScale = 0.7
+		energy = 1
+		speed = 0.75
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Upper
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Upper
+		}
+	}
+}
+
+@PART[liquidEngine2-2_v2]:BEFORE[RealPlume] // RE-L10 "Poodle V2" (Reskin from update 1.6)
+{
+	PLUME
+	{
+		name = Hypergolic-OMS-Red
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.75
+		fixedScale = 1
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hypergolic-OMS-White
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,-0.1
+		fixedScale = 0.45
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-OMS-Red
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hypergolic-OMS-White
+		}
+	}
+}
+
+@PART[liquidEngineMini_v2]:BEFORE[RealPlume] // 48-7S "Spark V2" (Reskin from update 1.6)
+{
+	PLUME
+	{
+		name = Kerolox-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.05
+		plumePosition = 0,0,0.075
+		flareScale = 0.15
+		plumeScale = 0.1
+		energy = 1
+		speed = 0.7
+	}
+	PLUME
+	{
+		name = Hypergolic-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.45
+		plumePosition = 0,0,0.1
+		fixedScale = 0.25
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.75
+		plumePosition = 0,0,1.05
+		fixedScale = 0.25
+		energy = 1
+		speed = 0.75
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Lower
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Lower
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Lower
+		}
+	}
+}
+
+@PART[LiquidEngineLV-TX87]:BEFORE[RealPlume] // LV-TX87 "Bobcat" (Making History DLC)
+{
+	PLUME
+	{
+		name = Kerolox-Upper
+		transformName = thrustTransform
+		flarePosition = 0,0,0.9
+		flareScale = 0.9
+		plumePosition = 0,0,1
+		plumeScale = 0.6
+		energy = 1
+		speed = 0.7
+	}
+	PLUME
+	{
+		name = Hypergolic-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,1.4
+		plumePosition = 0,0,1.25
+		fixedScale = 1.4
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,1.5
+		plumePosition = 0,0,1.9
+		fixedScale = 1.1
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Upper
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Upper
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Upper
+		}
+	}
+}
+
+@PART[LiquidEngineKE-1]:BEFORE[RealPlume] // Kerbodyne KE-1 "Mastodon" (Making History DLC)
+{
+	PLUME
+	{
+		name = Kerolox-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,1.25
+		flareScale = 1
+		plumePosition = 0,0,1.5
+		plumeScale = 0.9
+		energy = 1
+		speed = 0.6
+	}
+	PLUME
+	{
+		name = Hypergolic-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,1.75
+		fixedScale = 1.75
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,2
+		plumePosition = 0,0,2.5
+		fixedScale = 1.4
+		energy = 1
+		speed = 0.7
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Lower
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Lower
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Lower
+		}
+	}
+}
+
+@PART[LiquidEngineLV-T91]:BEFORE[RealPlume] // LV-T91 "Cheetah" (Making History DLC)
+{
+	PLUME
+	{
+		name = Hypergolic-OMS-Red
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.75
+		fixedScale = 1
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hypergolic-OMS-White
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,-0.1
+		fixedScale = 0.45
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-OMS-Red
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hypergolic-OMS-White
+		}
+	}
+}
+
+@PART[LiquidEngineRE-I2]:BEFORE[RealPlume] // RE-I2 "Skiff" (Making History DLC)
+{
+	PLUME
+	{
+		name = Kerolox-Upper
+		transformName = thrustTransform
+		flarePosition = 0,0,0.9
+		flareScale = 0.9
+		plumePosition = 0,0,1
+		plumeScale = 0.6
+		energy = 1
+		speed = 0.7
+	}
+	PLUME
+	{
+		name = Hypergolic-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,1.4
+		plumePosition = 0,0,1.25
+		fixedScale = 1.4
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Upper
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,1.5
+		plumePosition = 0,0,1.9
+		fixedScale = 1.1
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Upper
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Upper
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Upper
+		}
+	}
+}
+
+@PART[LiquidEngineRE-J10]:BEFORE[RealPlume] // RE-J10 "Wolfhound" (Making History DLC)
+{
+	PLUME
+	{
+		name = Hypergolic-OMS-Red
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.75
+		fixedScale = 1
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hypergolic-OMS-White
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,-0.1
+		fixedScale = 0.45
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		@type = ModuleEnginesRF
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-OMS-Red
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hypergolic-OMS-White
+		}
+	}
+}
+
+@PART[LiquidEngineRK-7]:BEFORE[RealPlume] // RK-7 "Kodiak" (Making History DLC)
+{
+	PLUME
+	{
+		name = Kerolox-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.5
+		flareScale = 0.55
+		plumeScale = 0.45
+		energy = 1
+		speed = 0.75
+	}
+	PLUME
+	{
+		name = Hypergolic-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.9
+		fixedScale = 0.25
+		energy = 1
+		speed = 1
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Lower
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Lower
+		}
+	}
+}
+
+@PART[LiquidEngineRV-1]:BEFORE[RealPlume] // RV-1 "Cub" (Making History DLC)
+{
+	PLUME
+	{
+		name = Kerolox-Lower
+		transformName = thrustTransform
+		localRotation = -5,0,0
+		flarelPosition = 0,0,0.05
+		plumePosition = 0,0,0.075
+		flareScale = 0.12
+		plumeScale = 0.05
+		energy = 1
+		speed = 0.7
+	}
+	PLUME
+	{
+		name = Hypergolic-Lower
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		flarePosition = 0,0,0.45
+		plumePosition = 0,0,0.1
+		fixedScale = 0.25
+		energy = 1
+		speed = 1
+	}
+	PLUME
+	{
+		name = Hydrolox-Lower
+		transformName = thrustTransform
+		localRotation = 1,0,0
+		flarePosition = 0,0,0.5
+		plumePosition = 0,0,1.05
+		fixedScale = 0.2
+		energy = 1
+		speed = 0.75
+	}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesRF
+	}
+	@MODULE[ModuleEngineConfigs]
+	{
+		%type = ModuleEnginesRF
+		@CONFIG[Kerosene+LqdOxygen]
+		{
+			%powerEffectName = Kerolox-Lower
+		}
+		@CONFIG[Aerozine50+NTO]
+		{
+			%powerEffectName = Hypergolic-Lower
+		}
+		@CONFIG[LqdHydrogen+LqdOxygen]
+		{
+			%powerEffectName = Hydrolox-Lower
+		}
+	}
+}


### PR DESCRIPTION
User Iso-Polaris made the configs for the engine reskins from update 1.6 and the new making history engines, but the plumes for the Real Plumes were not configured.
This commit aims to fix that, adding new plume configs for the already configured new engines.