### PR TITLE
Fix version file syntax

### DIFF
--- a/GameData/RealFuels-Stockalike/RFStockalike.version
+++ b/GameData/RealFuels-Stockalike/RFStockalike.version
@@ -1,21 +1,18 @@
 {
-    "NAME":"RealFuels Stockalike Configs",
-    "URL":"https://raw.githubusercontent.com/Raptor831/RFStockalike/master/GameData/RealFuels-Stockalike/RFStockalike.version"
-    "GITHUB":
-    {
-        "USERNAME":"Raptor831",
-        "REPOSITORY":"RFStockalike",
-        "ALLOW_PRE_RELEASE":false,
+    "NAME": "RealFuels Stockalike Configs",
+    "URL": "https://raw.githubusercontent.com/Raptor831/RFStockalike/master/GameData/RealFuels-Stockalike/RFStockalike.version",
+    "GITHUB": {
+        "USERNAME": "Raptor831",
+        "REPOSITORY": "RFStockalike",
+        "ALLOW_PRE_RELEASE": false
     },
-    "VERSION":
-    {
+    "VERSION": {
         "MAJOR":3,
         "MINOR":2,
         "PATCH":3,
         "BUILD":0
     },
-    "KSP_VERSION":
-    {
+    "KSP_VERSION": {
         "MAJOR":1,
         "MINOR":3,
         "PATCH":1


### PR DESCRIPTION
The version file has two syntax errors, there's a missing comma and an extra comma. Now it's fixed.

FYI to @Raptor831.