### PR TITLE
Update ~_v2's in Stockalike_Squad.cfg

### DIFF
--- a/GameData/RealFuels-Stockalike/Stockalike_Squad.cfg
+++ b/GameData/RealFuels-Stockalike/Stockalike_Squad.cfg
@@ -1322,7 +1322,345 @@
 
 
 }
+ @PART[Size2LFB_v2]:FOR[RealFuels_StockEngines] //LFB KR-1×2.v2
+{
+
+  @mass = 3.1
+  @cost = 6203
+  %entryCost = 31015
+  @maxTemp = 2375
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 2000
+    @heatProduction = 181
+    @atmosphereCurve
+    {
+      @key,0 = 0 332
+      @key,1 = 1 299
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L
+    origMass = 3.1
+    configuration = Kerosene+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 2000
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 20
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 2000
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 20
+      }
+
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1500
+      heatProduction = 181
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 20
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 20
+  }
+
+  !RESOURCE[LiquidFuel] {}
+  !RESOURCE[Oxidizer] {}
+  !RESOURCE[MonoPropellant] {}
+  !RESOURCE[SolidFuel] {}
+  !RESOURCE[XenonGas] {}
+  MODULE
+  {
+    name = ModuleFuelTanks
+    basemass = -1
+    volume = 32000
+    type = Default
+    // dedicated = false
+    TANK
+    {
+     name = Kerosene
+     amount = full
+     maxAmount = 37.694087%
+    }
+    TANK
+    {
+     name = LqdOxygen
+     amount = full
+     maxAmount = 62.305913%
+    }
+  }
+
+
+}
  @PART[engineLargeSkipper]:FOR[RealFuels_StockEngines] //Skipper
+{
+
+  @mass = 1
+  @cost = 1860
+  %entryCost = 9300
+  @maxTemp = 1948
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 650
+    @heatProduction = 138
+    @atmosphereCurve
+    {
+      @key,0 = 0 345
+      @key,1 = 1 207
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 5
+    origTechLevel = 5
+    engineType = U
+    origMass = 1
+    configuration = Kerosene+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 650
+      heatProduction = 138
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 6.5
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 650
+      heatProduction = 138
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 4
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 6.5
+      }
+
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 488
+      heatProduction = 138
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 6.5
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 6.5
+  }
+
+
+}
+ @PART[engineLargeSkipper_v2]:FOR[RealFuels_StockEngines] //Skipper.v2
 {
 
   @mass = 1
@@ -1603,6 +1941,162 @@
 
 }
  @PART[liquidEngine1-2]:FOR[RealFuels_StockEngines] //Mainsail
+{
+
+  @mass = 2
+  @cost = 5024
+  %entryCost = 25120
+  @maxTemp = 2266
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 1500
+    @heatProduction = 170
+    @atmosphereCurve
+    {
+      @key,0 = 0 342
+      @key,1 = 1 281
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 6
+    origTechLevel = 6
+    engineType = L+
+    origMass = 2
+    configuration = Kerosene+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 1500
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 1500
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 2
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15
+      }
+
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 1125
+      heatProduction = 170
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 15
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 15
+  }
+
+
+}
+ @PART[liquidEngineMainsail_v2]:FOR[RealFuels_StockEngines] //Mainsail.v2
 {
 
   @mass = 2
@@ -2521,6 +3015,162 @@
 
 
 }
+ @PART[liquidEngine2_v2]:FOR[RealFuels_StockEngines] //LV-T45.v2
+{
+
+  @mass = 0.42
+  @cost = 445
+  %entryCost = 2225
+  @maxTemp = 1797
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 190
+    @heatProduction = 145
+    @atmosphereCurve
+    {
+      @key,0 = 0 283
+      @key,1 = 1 233
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Ethanol75
+      ratio = 52.660728
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 47.339272
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 2
+    origTechLevel = 2
+    engineType = L+
+    origMass = 0.42
+    configuration = Ethanol75+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 190
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9300
+      IspV = 0.9300
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 200
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 2
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 200
+      heatProduction = 145
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 2
+  }
+
+
+}
  @PART[liquidEngine2]:FOR[RealFuels_StockEngines] //LV-T45
 {
 
@@ -2677,7 +3327,162 @@
 
 
 }
- @PART[liquidEngine]:FOR[RealFuels_StockEngines] //LV-T30
+ @PART[liquidEngine_v2]:FOR[RealFuels_StockEngines] //LV-T30.v2
+{
+
+  @mass = 0.42
+  @cost = 314
+  %entryCost = 1570
+  @maxTemp = 1891
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 204
+    @heatProduction = 154
+    @atmosphereCurve
+    {
+      @key,0 = 0 256
+      @key,1 = 1 231
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Ethanol75
+      ratio = 52.660728
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 47.339272
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 1
+    origTechLevel = 1
+    engineType = L
+    origMass = 0.42
+    configuration = Ethanol75+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Ethanol75+LqdOxygen
+      maxThrust = 204
+      heatProduction = 154
+      PROPELLANT
+      {
+        name = Ethanol75
+        ratio = 52.66072829648775
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 47.33927170351225
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9300
+      IspV = 0.9300
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2.15
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 215
+      heatProduction = 154
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2.15
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 215
+      heatProduction = 154
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 2.15
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 2.15
+  }
+
+
+} @PART[liquidEngine]:FOR[RealFuels_StockEngines] //LV-T30
 {
 
   @mass = 0.42
@@ -3128,6 +3933,162 @@
 
 
 }
+ @PART[smallRadialEngine_v2]:FOR[RealFuels_StockEngines] //24-77.v2
+{
+
+  @mass = 0.025
+  @cost = 126
+  %entryCost = 630
+  @maxTemp = 2230
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 20
+    @heatProduction = 173
+    @atmosphereCurve
+    {
+      @key,0 = 0 320
+      @key,1 = 1 288
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Kerosene
+      ratio = 37.694087
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = LqdOxygen
+      ratio = 62.305913
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 4
+    origTechLevel = 4
+    engineType = L
+    origMass = 0.025
+    configuration = Kerosene+LqdOxygen
+    modded = false
+
+    CONFIG
+    {
+      name = Kerosene+LqdOxygen
+      maxThrust = 20
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = Kerosene
+        ratio = 37.69408655434424
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 62.30591344565576
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.0000
+      IspV = 1.0000
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.2
+      }
+
+
+    }
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 20
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.2
+      }
+
+
+    }
+    CONFIG
+    {
+      name = LqdHydrogen+LqdOxygen
+      maxThrust = 15
+      heatProduction = 173
+      PROPELLANT
+      {
+        name = LqdHydrogen
+        ratio = 76.30830964721619
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = LqdOxygen
+        ratio = 23.69169035278381
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 1.3000
+      IspV = 1.2700
+      throttle = 0
+      ignitions = 1
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.2
+      }
+
+
+    }
+  }
+  ignitions = 1
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 0.2
+  }
+
+
+}
  @PART[radialEngineMini]:FOR[RealFuels_StockEngines] //LV-1R
 {
 
@@ -3221,6 +4182,98 @@
 
 }
  @PART[microEngine]:FOR[RealFuels_StockEngines] //LV-1
+{
+
+  @mass = 0.005
+  @cost = 78
+  %entryCost = 390
+  @maxTemp = 1523
+
+
+  @MODULE[ModuleEngine*]
+  {
+    @name = ModuleEnginesRF
+    @maxThrust = 2
+    @heatProduction = 95
+    @atmosphereCurve
+    {
+      @key,0 = 0 330
+      @key,1 = 1 116
+    }
+    !PROPELLANT[LiquidFuel] {}
+    !PROPELLANT[Oxidizer] {}
+    !PROPELLANT[MonoPropellant] {}
+    PROPELLANT
+    {
+      name = Aerozine50
+      ratio = 50.173010
+      DrawGauge = True
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+    PROPELLANT
+    {
+      name = NTO
+      ratio = 49.826990
+      %resourceFlowMode = STACK_PRIORITY_SEARCH
+    }
+  }
+
+  MODULE
+  {
+    name = ModuleEngineConfigs
+    type = ModuleEnginesRF
+    techLevel = 4
+    origTechLevel = 4
+    engineType = O
+    origMass = 0.0045
+    configuration = Aerozine50+NTO
+    modded = false
+
+    CONFIG
+    {
+      name = Aerozine50+NTO
+      maxThrust = 2
+      heatProduction = 95
+      PROPELLANT
+      {
+        name = Aerozine50
+        ratio = 50.17301038062284
+        DrawGauge = True
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      PROPELLANT
+      {
+        name = NTO
+        ratio = 49.82698961937716
+        %resourceFlowMode = STACK_PRIORITY_SEARCH
+      }
+      IspSL = 0.9600
+      IspV = 0.9500
+      throttle = 0
+      ignitions = 24
+      ullage = true
+      pressureFed = false
+      IGNITOR_RESOURCE
+      {
+        name = ElectricCharge
+        amount = 0.015
+      }
+
+
+    }
+  }
+  ignitions = 24
+  ullage = true
+  pressureFed = false
+  IGNITOR_RESOURCE
+  {
+    name = ElectricCharge
+    amount = 0.015
+  }
+
+
+}
+ @PART[microEngine_v2]:FOR[RealFuels_StockEngines] //LV-1.v2
 {
 
   @mass = 0.005
@@ -3625,7 +4678,7 @@
 
 }
  @PART[liquidEngine3_v2]:FOR[RealFuels_StockEngines] // LV-909.v2
-{﻿
+{
 
   @mass = 0.2
   @cost = 146


### PR DESCRIPTION
I don't know what a problem was.

when I play a game, some _v2 part not loaded, but still work legacy engine (LV-T45, 30).

I think it is some old issued that https://github.com/Raptor831/RFStockalike/issues/108
but I don't know why It happen recent version that download from CKAN.
anyhow, this issue may have been solved on other pulls, but, I don't want a lose my fixed cfg file on my pc at future.
so, I just upload in the hub.

Still realplume have same issue, but you can use waterfall instead to solve.